### PR TITLE
feat: add Exec command, Result struct, and convenience API

### DIFF
--- a/lib/codex_wrapper.ex
+++ b/lib/codex_wrapper.ex
@@ -6,7 +6,16 @@ defmodule CodexWrapper do
 
   ## Quick start
 
+      # Simple one-shot exec
+      {:ok, result} = CodexWrapper.exec("fix the failing test", working_dir: "/path/to/project")
+
+      # Full control via Exec builder
       config = CodexWrapper.Config.new(working_dir: "/path/to/project")
+
+      CodexWrapper.Exec.new("implement the feature")
+      |> CodexWrapper.Exec.model("o3")
+      |> CodexWrapper.Exec.sandbox(:danger_full_access)
+      |> CodexWrapper.Exec.execute(config)
 
   ## Binary discovery
 
@@ -16,7 +25,7 @@ defmodule CodexWrapper do
   3. System PATH lookup
   """
 
-  alias CodexWrapper.Config
+  alias CodexWrapper.{Config, Exec, Result}
 
   @doc """
   Run an arbitrary CLI command that isn't wrapped by a dedicated module.
@@ -40,5 +49,82 @@ defmodule CodexWrapper do
     end
   rescue
     e in ErlangError -> {:error, {:system_cmd, e}}
+  end
+
+  @doc """
+  Execute a prompt non-interactively and return the result.
+
+  Convenience wrapper that builds a `Config` and `Exec` from keyword options.
+  Returns `{:ok, %Result{}}` on success or `{:error, reason}` on failure.
+
+  ## Options
+
+  Config options (passed to `Config.new/1`):
+    * `:binary` - Path to codex binary
+    * `:working_dir` - Working directory
+    * `:env` - Environment variables
+    * `:timeout` - Timeout in ms
+    * `:verbose` - Enable verbose output
+
+  Exec options (passed to `Exec` builder):
+    * `:model` - Model name
+    * `:sandbox` - Sandbox mode atom
+    * `:approval_policy` - Approval policy atom
+    * `:full_auto` - Enable full-auto (boolean)
+    * `:dangerously_bypass_approvals_and_sandbox` - Bypass all (boolean)
+    * `:cd` - Working directory for codex subprocess
+    * `:skip_git_repo_check` - Skip git check (boolean)
+    * `:search` - Enable web search (boolean)
+    * `:ephemeral` - Ephemeral mode (boolean)
+    * `:json` - JSON output (boolean)
+    * `:output_schema` - Output schema path
+    * `:output_last_message` - Output last message path
+
+  ## Examples
+
+      CodexWrapper.exec("fix the tests")
+      CodexWrapper.exec("implement the feature", working_dir: "/path/to/repo", model: "o3")
+  """
+  @spec exec(String.t(), keyword()) :: {:ok, Result.t()} | {:error, term()}
+  def exec(prompt, opts \\ []) do
+    {config_opts, exec_opts} = split_opts(opts)
+    config = Config.new(config_opts)
+    exec = build_exec(prompt, exec_opts)
+    Exec.execute(exec, config)
+  end
+
+  # --- Private ---
+
+  @config_keys [:binary, :working_dir, :env, :timeout, :verbose]
+
+  defp split_opts(opts) do
+    Enum.split_with(opts, fn {k, _v} -> k in @config_keys end)
+  end
+
+  defp build_exec(prompt, opts) do
+    exec = Exec.new(prompt)
+
+    Enum.reduce(opts, exec, fn
+      {:model, v}, e -> Exec.model(e, v)
+      {:sandbox, v}, e -> Exec.sandbox(e, v)
+      {:approval_policy, v}, e -> Exec.approval_policy(e, v)
+      {:full_auto, true}, e -> Exec.full_auto(e)
+      {:full_auto, false}, e -> e
+      {:dangerously_bypass_approvals_and_sandbox, true}, e ->
+        Exec.dangerously_bypass_approvals_and_sandbox(e)
+      {:dangerously_bypass_approvals_and_sandbox, false}, e -> e
+      {:cd, v}, e -> Exec.cd(e, v)
+      {:skip_git_repo_check, true}, e -> Exec.skip_git_repo_check(e)
+      {:skip_git_repo_check, false}, e -> e
+      {:search, true}, e -> Exec.search(e)
+      {:search, false}, e -> e
+      {:ephemeral, true}, e -> Exec.ephemeral(e)
+      {:ephemeral, false}, e -> e
+      {:json, true}, e -> Exec.json(e)
+      {:json, false}, e -> e
+      {:output_schema, v}, e -> Exec.output_schema(e, v)
+      {:output_last_message, v}, e -> Exec.output_last_message(e, v)
+      _other, e -> e
+    end)
   end
 end

--- a/lib/codex_wrapper/exec.ex
+++ b/lib/codex_wrapper/exec.ex
@@ -1,0 +1,222 @@
+defmodule CodexWrapper.Exec do
+  @moduledoc """
+  Exec command — the primary interface for non-interactive prompts.
+
+  Wraps `codex exec <prompt>` with the full set of CLI flags.
+
+  ## Usage
+
+      config = CodexWrapper.Config.new(working_dir: "/path/to/project")
+
+      # Build an exec command
+      exec = CodexWrapper.Exec.new("Fix the failing test")
+        |> CodexWrapper.Exec.model("o3")
+        |> CodexWrapper.Exec.sandbox(:workspace_write)
+        |> CodexWrapper.Exec.ephemeral()
+
+      # Execute (returns result)
+      {:ok, result} = CodexWrapper.Exec.execute(exec, config)
+  """
+
+  @behaviour CodexWrapper.Command
+
+  alias CodexWrapper.{Command, Config, Result}
+
+  @type sandbox_mode :: :read_only | :workspace_write | :danger_full_access
+  @type approval_policy :: :untrusted | :on_failure | :on_request | :never
+
+  @type t :: %__MODULE__{
+          prompt: String.t(),
+          model: String.t() | nil,
+          sandbox: sandbox_mode() | nil,
+          approval_policy: approval_policy() | nil,
+          full_auto: boolean(),
+          dangerously_bypass_approvals_and_sandbox: boolean(),
+          cd: String.t() | nil,
+          skip_git_repo_check: boolean(),
+          add_dirs: [String.t()],
+          search: boolean(),
+          ephemeral: boolean(),
+          output_schema: String.t() | nil,
+          json: boolean(),
+          output_last_message: String.t() | nil,
+          images: [String.t()],
+          config_overrides: [String.t()],
+          enabled_features: [String.t()],
+          disabled_features: [String.t()]
+        }
+
+  defstruct [
+    :prompt,
+    :model,
+    :sandbox,
+    :approval_policy,
+    :cd,
+    :output_schema,
+    :output_last_message,
+    full_auto: false,
+    dangerously_bypass_approvals_and_sandbox: false,
+    skip_git_repo_check: false,
+    search: false,
+    ephemeral: false,
+    json: false,
+    add_dirs: [],
+    images: [],
+    config_overrides: [],
+    enabled_features: [],
+    disabled_features: []
+  ]
+
+  # --- Constructor ---
+
+  @doc """
+  Create a new exec command with the given prompt.
+  """
+  @spec new(String.t()) :: t()
+  def new(prompt) when is_binary(prompt) do
+    %__MODULE__{prompt: prompt}
+  end
+
+  # --- Builder functions ---
+
+  @doc "Set the model."
+  @spec model(t(), String.t()) :: t()
+  def model(%__MODULE__{} = e, model), do: %{e | model: model}
+
+  @doc "Set the sandbox mode."
+  @spec sandbox(t(), sandbox_mode()) :: t()
+  def sandbox(%__MODULE__{} = e, mode), do: %{e | sandbox: mode}
+
+  @doc "Set the approval policy."
+  @spec approval_policy(t(), approval_policy()) :: t()
+  def approval_policy(%__MODULE__{} = e, policy), do: %{e | approval_policy: policy}
+
+  @doc "Enable full-auto mode."
+  @spec full_auto(t()) :: t()
+  def full_auto(%__MODULE__{} = e), do: %{e | full_auto: true}
+
+  @doc "Bypass all approvals and sandbox. Use with extreme caution."
+  @spec dangerously_bypass_approvals_and_sandbox(t()) :: t()
+  def dangerously_bypass_approvals_and_sandbox(%__MODULE__{} = e),
+    do: %{e | dangerously_bypass_approvals_and_sandbox: true}
+
+  @doc "Set the working directory for the codex subprocess."
+  @spec cd(t(), String.t()) :: t()
+  def cd(%__MODULE__{} = e, dir), do: %{e | cd: dir}
+
+  @doc "Skip the git repo check."
+  @spec skip_git_repo_check(t()) :: t()
+  def skip_git_repo_check(%__MODULE__{} = e), do: %{e | skip_git_repo_check: true}
+
+  @doc "Add a directory for context."
+  @spec add_dir(t(), String.t()) :: t()
+  def add_dir(%__MODULE__{} = e, dir), do: %{e | add_dirs: e.add_dirs ++ [dir]}
+
+  @doc "Enable live web search."
+  @spec search(t()) :: t()
+  def search(%__MODULE__{} = e), do: %{e | search: true}
+
+  @doc "Enable ephemeral mode (no session persistence)."
+  @spec ephemeral(t()) :: t()
+  def ephemeral(%__MODULE__{} = e), do: %{e | ephemeral: true}
+
+  @doc "Set the output schema path."
+  @spec output_schema(t(), String.t()) :: t()
+  def output_schema(%__MODULE__{} = e, path), do: %{e | output_schema: path}
+
+  @doc "Enable JSON output."
+  @spec json(t()) :: t()
+  def json(%__MODULE__{} = e), do: %{e | json: true}
+
+  @doc "Set the output-last-message path."
+  @spec output_last_message(t(), String.t()) :: t()
+  def output_last_message(%__MODULE__{} = e, path), do: %{e | output_last_message: path}
+
+  @doc "Add an image path."
+  @spec image(t(), String.t()) :: t()
+  def image(%__MODULE__{} = e, path), do: %{e | images: e.images ++ [path]}
+
+  @doc "Add a config override (key=value)."
+  @spec config(t(), String.t()) :: t()
+  def config(%__MODULE__{} = e, kv), do: %{e | config_overrides: e.config_overrides ++ [kv]}
+
+  @doc "Enable a feature."
+  @spec enable(t(), String.t()) :: t()
+  def enable(%__MODULE__{} = e, feature),
+    do: %{e | enabled_features: e.enabled_features ++ [feature]}
+
+  @doc "Disable a feature."
+  @spec disable(t(), String.t()) :: t()
+  def disable(%__MODULE__{} = e, feature),
+    do: %{e | disabled_features: e.disabled_features ++ [feature]}
+
+  # --- Execution ---
+
+  @doc """
+  Execute the command synchronously, returning a parsed `%Result{}`.
+  """
+  @spec execute(t(), Config.t()) :: {:ok, Result.t()} | {:error, term()}
+  def execute(%__MODULE__{} = exec, %Config{} = config) do
+    Command.run(__MODULE__, exec, config)
+  end
+
+  # --- Command behaviour ---
+
+  @impl Command
+  def args(%__MODULE__{} = e) do
+    ["exec"]
+    |> add_list("-c", e.config_overrides)
+    |> add_list("--enable", e.enabled_features)
+    |> add_list("--disable", e.disabled_features)
+    |> add_list("--image", e.images)
+    |> add_opt("--model", e.model)
+    |> add_opt("--sandbox", format_sandbox(e.sandbox))
+    |> add_opt("--ask-for-approval", format_approval_policy(e.approval_policy))
+    |> add_bool("--full-auto", e.full_auto)
+    |> add_bool("--dangerously-bypass-approvals-and-sandbox",
+         e.dangerously_bypass_approvals_and_sandbox)
+    |> add_opt("--cd", e.cd)
+    |> add_bool("--skip-git-repo-check", e.skip_git_repo_check)
+    |> add_list("--add-dir", e.add_dirs)
+    |> add_bool("--search", e.search)
+    |> add_bool("--ephemeral", e.ephemeral)
+    |> add_opt("--output-schema", e.output_schema)
+    |> add_bool("--json", e.json)
+    |> add_opt("--output-last-message", e.output_last_message)
+    |> add_flag(e.prompt)
+  end
+
+  @impl Command
+  def parse_output(stdout, exit_code) do
+    result = Result.from_cmd({stdout, exit_code})
+
+    if result.success do
+      {:ok, result}
+    else
+      {:ok, result}
+    end
+  end
+
+  # --- Arg helpers ---
+
+  defp add_flag(args, value), do: args ++ [value]
+  defp add_opt(args, _flag, nil), do: args
+  defp add_opt(args, flag, value), do: args ++ [flag, value]
+  defp add_bool(args, _flag, false), do: args
+  defp add_bool(args, flag, true), do: args ++ [flag]
+  defp add_list(args, _flag, []), do: args
+  defp add_list(args, flag, values), do: args ++ Enum.flat_map(values, &[flag, &1])
+
+  # --- Format helpers ---
+
+  defp format_sandbox(nil), do: nil
+  defp format_sandbox(:read_only), do: "read-only"
+  defp format_sandbox(:workspace_write), do: "workspace-write"
+  defp format_sandbox(:danger_full_access), do: "danger-full-access"
+
+  defp format_approval_policy(nil), do: nil
+  defp format_approval_policy(:untrusted), do: "untrusted"
+  defp format_approval_policy(:on_failure), do: "on-failure"
+  defp format_approval_policy(:on_request), do: "on-request"
+  defp format_approval_policy(:never), do: "never"
+end

--- a/lib/codex_wrapper/result.ex
+++ b/lib/codex_wrapper/result.ex
@@ -1,0 +1,37 @@
+defmodule CodexWrapper.Result do
+  @moduledoc """
+  Result from a completed exec command.
+
+  Maps to the Rust `CommandOutput` — the raw output from `System.cmd`.
+  """
+
+  @type t :: %__MODULE__{
+          stdout: String.t(),
+          stderr: String.t(),
+          exit_code: non_neg_integer(),
+          success: boolean()
+        }
+
+  defstruct [
+    :stdout,
+    :stderr,
+    :exit_code,
+    success: false
+  ]
+
+  @doc """
+  Build a result from `System.cmd/3` output.
+
+  `System.cmd` with `:stderr_to_stdout` merges stderr into stdout,
+  so `stderr` is always `""` in that case.
+  """
+  @spec from_cmd({String.t(), non_neg_integer()}, keyword()) :: t()
+  def from_cmd({output, exit_code}, _opts \\ []) do
+    %__MODULE__{
+      stdout: output,
+      stderr: "",
+      exit_code: exit_code,
+      success: exit_code == 0
+    }
+  end
+end

--- a/test/codex_wrapper/exec_test.exs
+++ b/test/codex_wrapper/exec_test.exs
@@ -1,0 +1,240 @@
+defmodule CodexWrapper.ExecTest do
+  use ExUnit.Case, async: true
+
+  alias CodexWrapper.Exec
+
+  describe "new/1" do
+    test "sets the prompt" do
+      exec = Exec.new("fix the test")
+      assert exec.prompt == "fix the test"
+    end
+
+    test "defaults" do
+      exec = Exec.new("prompt")
+      assert exec.model == nil
+      assert exec.sandbox == nil
+      assert exec.approval_policy == nil
+      assert exec.full_auto == false
+      assert exec.dangerously_bypass_approvals_and_sandbox == false
+      assert exec.cd == nil
+      assert exec.skip_git_repo_check == false
+      assert exec.add_dirs == []
+      assert exec.search == false
+      assert exec.ephemeral == false
+      assert exec.output_schema == nil
+      assert exec.json == false
+      assert exec.output_last_message == nil
+      assert exec.images == []
+      assert exec.config_overrides == []
+      assert exec.enabled_features == []
+      assert exec.disabled_features == []
+    end
+  end
+
+  describe "builder functions" do
+    test "model/2" do
+      exec = Exec.new("p") |> Exec.model("o3")
+      assert exec.model == "o3"
+    end
+
+    test "sandbox/2" do
+      exec = Exec.new("p") |> Exec.sandbox(:workspace_write)
+      assert exec.sandbox == :workspace_write
+    end
+
+    test "approval_policy/2" do
+      exec = Exec.new("p") |> Exec.approval_policy(:on_request)
+      assert exec.approval_policy == :on_request
+    end
+
+    test "full_auto/1" do
+      exec = Exec.new("p") |> Exec.full_auto()
+      assert exec.full_auto == true
+    end
+
+    test "dangerously_bypass_approvals_and_sandbox/1" do
+      exec = Exec.new("p") |> Exec.dangerously_bypass_approvals_and_sandbox()
+      assert exec.dangerously_bypass_approvals_and_sandbox == true
+    end
+
+    test "cd/2" do
+      exec = Exec.new("p") |> Exec.cd("/tmp")
+      assert exec.cd == "/tmp"
+    end
+
+    test "skip_git_repo_check/1" do
+      exec = Exec.new("p") |> Exec.skip_git_repo_check()
+      assert exec.skip_git_repo_check == true
+    end
+
+    test "add_dir/2 accumulates" do
+      exec = Exec.new("p") |> Exec.add_dir("/a") |> Exec.add_dir("/b")
+      assert exec.add_dirs == ["/a", "/b"]
+    end
+
+    test "search/1" do
+      exec = Exec.new("p") |> Exec.search()
+      assert exec.search == true
+    end
+
+    test "ephemeral/1" do
+      exec = Exec.new("p") |> Exec.ephemeral()
+      assert exec.ephemeral == true
+    end
+
+    test "output_schema/2" do
+      exec = Exec.new("p") |> Exec.output_schema("schema.json")
+      assert exec.output_schema == "schema.json"
+    end
+
+    test "json/1" do
+      exec = Exec.new("p") |> Exec.json()
+      assert exec.json == true
+    end
+
+    test "output_last_message/2" do
+      exec = Exec.new("p") |> Exec.output_last_message("/tmp/msg.json")
+      assert exec.output_last_message == "/tmp/msg.json"
+    end
+
+    test "image/2 accumulates" do
+      exec = Exec.new("p") |> Exec.image("a.png") |> Exec.image("b.png")
+      assert exec.images == ["a.png", "b.png"]
+    end
+
+    test "config/2 accumulates" do
+      exec = Exec.new("p") |> Exec.config("key=val") |> Exec.config("k2=v2")
+      assert exec.config_overrides == ["key=val", "k2=v2"]
+    end
+
+    test "enable/2 accumulates" do
+      exec = Exec.new("p") |> Exec.enable("feat1") |> Exec.enable("feat2")
+      assert exec.enabled_features == ["feat1", "feat2"]
+    end
+
+    test "disable/2 accumulates" do
+      exec = Exec.new("p") |> Exec.disable("feat1")
+      assert exec.disabled_features == ["feat1"]
+    end
+  end
+
+  describe "args/1" do
+    test "minimal args" do
+      args = Exec.new("fix the test") |> Exec.args()
+      assert args == ["exec", "fix the test"]
+    end
+
+    test "full args match Rust ordering" do
+      args =
+        Exec.new("fix the test")
+        |> Exec.model("gpt-5")
+        |> Exec.sandbox(:workspace_write)
+        |> Exec.approval_policy(:on_request)
+        |> Exec.skip_git_repo_check()
+        |> Exec.ephemeral()
+        |> Exec.json()
+        |> Exec.args()
+
+      assert args == [
+               "exec",
+               "--model", "gpt-5",
+               "--sandbox", "workspace-write",
+               "--ask-for-approval", "on-request",
+               "--skip-git-repo-check",
+               "--ephemeral",
+               "--json",
+               "fix the test"
+             ]
+    end
+
+    test "config overrides come first" do
+      args =
+        Exec.new("prompt")
+        |> Exec.config("key=val")
+        |> Exec.model("o3")
+        |> Exec.args()
+
+      config_idx = Enum.find_index(args, &(&1 == "-c"))
+      model_idx = Enum.find_index(args, &(&1 == "--model"))
+      assert config_idx < model_idx
+    end
+
+    test "list flags repeat" do
+      args =
+        Exec.new("prompt")
+        |> Exec.image("a.png")
+        |> Exec.image("b.png")
+        |> Exec.add_dir("/x")
+        |> Exec.add_dir("/y")
+        |> Exec.args()
+
+      assert "--image" in args
+      assert "a.png" in args
+      assert "b.png" in args
+      assert "--add-dir" in args
+      assert "/x" in args
+      assert "/y" in args
+    end
+
+    test "boolean flags" do
+      args =
+        Exec.new("prompt")
+        |> Exec.full_auto()
+        |> Exec.dangerously_bypass_approvals_and_sandbox()
+        |> Exec.search()
+        |> Exec.args()
+
+      assert "--full-auto" in args
+      assert "--dangerously-bypass-approvals-and-sandbox" in args
+      assert "--search" in args
+    end
+
+    test "sandbox modes" do
+      assert "--sandbox" in (Exec.new("p") |> Exec.sandbox(:read_only) |> Exec.args())
+
+      args = Exec.new("p") |> Exec.sandbox(:read_only) |> Exec.args()
+      idx = Enum.find_index(args, &(&1 == "--sandbox"))
+      assert Enum.at(args, idx + 1) == "read-only"
+
+      args = Exec.new("p") |> Exec.sandbox(:danger_full_access) |> Exec.args()
+      idx = Enum.find_index(args, &(&1 == "--sandbox"))
+      assert Enum.at(args, idx + 1) == "danger-full-access"
+    end
+
+    test "approval policies" do
+      args = Exec.new("p") |> Exec.approval_policy(:untrusted) |> Exec.args()
+      idx = Enum.find_index(args, &(&1 == "--ask-for-approval"))
+      assert Enum.at(args, idx + 1) == "untrusted"
+
+      args = Exec.new("p") |> Exec.approval_policy(:never) |> Exec.args()
+      idx = Enum.find_index(args, &(&1 == "--ask-for-approval"))
+      assert Enum.at(args, idx + 1) == "never"
+    end
+
+    test "prompt is always last" do
+      args =
+        Exec.new("the prompt")
+        |> Exec.model("o3")
+        |> Exec.json()
+        |> Exec.args()
+
+      assert List.last(args) == "the prompt"
+    end
+  end
+
+  describe "parse_output/2" do
+    test "returns result for exit code 0" do
+      assert {:ok, result} = Exec.parse_output("output text\n", 0)
+      assert result.stdout == "output text\n"
+      assert result.exit_code == 0
+      assert result.success == true
+    end
+
+    test "returns result for non-zero exit code" do
+      assert {:ok, result} = Exec.parse_output("error\n", 1)
+      assert result.stdout == "error\n"
+      assert result.exit_code == 1
+      assert result.success == false
+    end
+  end
+end

--- a/test/codex_wrapper/result_test.exs
+++ b/test/codex_wrapper/result_test.exs
@@ -1,0 +1,30 @@
+defmodule CodexWrapper.ResultTest do
+  use ExUnit.Case, async: true
+
+  alias CodexWrapper.Result
+
+  describe "from_cmd/2" do
+    test "success" do
+      result = Result.from_cmd({"output text\n", 0})
+      assert result.stdout == "output text\n"
+      assert result.stderr == ""
+      assert result.exit_code == 0
+      assert result.success == true
+    end
+
+    test "failure" do
+      result = Result.from_cmd({"error message\n", 1})
+      assert result.stdout == "error message\n"
+      assert result.stderr == ""
+      assert result.exit_code == 1
+      assert result.success == false
+    end
+
+    test "exit code 2" do
+      result = Result.from_cmd({"", 2})
+      assert result.stdout == ""
+      assert result.exit_code == 2
+      assert result.success == false
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Exec` struct implementing the `Command` behaviour with builder functions for all exec options (model, sandbox, approval_policy, full_auto, cd, images, config overrides, feature flags, etc.)
- Add `Result` struct with `from_cmd/2` to parse `System.cmd` output into structured results
- Add `CodexWrapper.exec/2` convenience function that splits opts into config vs exec options and delegates to `Exec.execute/2`
- Mirrors the architecture of claude_wrapper_ex and the Rust codex-wrapper

## Files changed
- `lib/codex_wrapper/exec.ex` - Exec struct with builder pattern and Command behaviour implementation
- `lib/codex_wrapper/result.ex` - Result struct for parsing command output
- `lib/codex_wrapper.ex` - Added `exec/2` convenience function
- `test/codex_wrapper/exec_test.exs` - Tests for constructor, builders, arg building, and output parsing
- `test/codex_wrapper/result_test.exs` - Tests for `from_cmd/2` with success/failure cases

## Test plan
- [x] 47 tests pass locally (`mix test`)
- [x] No compiler warnings (`mix compile --warnings-as-errors`)

Closes #2