### PR TITLE
feat: add JsonLineEvent, execute_json/2, and stream/2

### DIFF
--- a/lib/codex_wrapper.ex
+++ b/lib/codex_wrapper.ex
@@ -25,7 +25,7 @@ defmodule CodexWrapper do
   3. System PATH lookup
   """
 
-  alias CodexWrapper.{Config, Exec, Result}
+  alias CodexWrapper.{Config, Exec, JsonLineEvent, Result}
 
   @doc """
   Run an arbitrary CLI command that isn't wrapped by a dedicated module.
@@ -91,6 +91,41 @@ defmodule CodexWrapper do
     config = Config.new(config_opts)
     exec = build_exec(prompt, exec_opts)
     Exec.execute(exec, config)
+  end
+
+  @doc """
+  Execute a prompt with `--json` and return parsed NDJSON events.
+
+  See `exec/2` for available options.
+
+  ## Examples
+
+      {:ok, events} = CodexWrapper.exec_json("fix the tests")
+  """
+  @spec exec_json(String.t(), keyword()) :: {:ok, [JsonLineEvent.t()]} | {:error, term()}
+  def exec_json(prompt, opts \\ []) do
+    {config_opts, exec_opts} = split_opts(opts)
+    config = Config.new(config_opts)
+    exec = build_exec(prompt, exec_opts)
+    Exec.execute_json(exec, config)
+  end
+
+  @doc """
+  Execute a prompt and return a lazy stream of `%JsonLineEvent{}`.
+
+  See `exec/2` for available options.
+
+  ## Examples
+
+      CodexWrapper.stream("fix the tests")
+      |> Enum.each(fn event -> IO.inspect(event.event_type) end)
+  """
+  @spec stream(String.t(), keyword()) :: Enumerable.t()
+  def stream(prompt, opts \\ []) do
+    {config_opts, exec_opts} = split_opts(opts)
+    config = Config.new(config_opts)
+    exec = build_exec(prompt, exec_opts)
+    Exec.stream(exec, config)
   end
 
   # --- Private ---

--- a/lib/codex_wrapper/exec.ex
+++ b/lib/codex_wrapper/exec.ex
@@ -20,7 +20,7 @@ defmodule CodexWrapper.Exec do
 
   @behaviour CodexWrapper.Command
 
-  alias CodexWrapper.{Command, Config, Result}
+  alias CodexWrapper.{Command, Config, JsonLineEvent, Result}
 
   @type sandbox_mode :: :read_only | :workspace_write | :danger_full_access
   @type approval_policy :: :untrusted | :on_failure | :on_request | :never
@@ -160,6 +160,88 @@ defmodule CodexWrapper.Exec do
     Command.run(__MODULE__, exec, config)
   end
 
+  @doc """
+  Execute the command with `--json` and return a list of parsed `%JsonLineEvent{}`.
+
+  Forces `--json` on the exec command, runs synchronously, then parses
+  each NDJSON line from stdout.
+  """
+  @spec execute_json(t(), Config.t()) :: {:ok, [JsonLineEvent.t()]} | {:error, term()}
+  def execute_json(%__MODULE__{} = exec, %Config{} = config) do
+    exec = %{exec | json: true}
+
+    case execute(exec, config) do
+      {:ok, result} ->
+        events =
+          result.stdout
+          |> String.split("\n", trim: true)
+          |> Enum.filter(&String.starts_with?(String.trim_leading(&1), "{"))
+          |> Enum.flat_map(fn line ->
+            case JsonLineEvent.parse(line) do
+              {:ok, event} -> [event]
+              {:error, _} -> []
+            end
+          end)
+
+        {:ok, events}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  @doc """
+  Execute the command and return a lazy `Stream` of `%JsonLineEvent{}`.
+
+  Uses a Port with `:line` mode to read NDJSON output line-by-line.
+  The port is opened when the stream is consumed and closed when
+  the stream terminates.
+
+  Forces `--json` on the exec command.
+  """
+  @spec stream(t(), Config.t()) :: Enumerable.t()
+  def stream(%__MODULE__{} = exec, %Config{} = config) do
+    exec = %{exec | json: true}
+    args = Config.base_args(config) ++ args(exec)
+
+    port_opts =
+      [:binary, :exit_status, {:line, 1_048_576}, {:args, args}] ++
+        port_env_opts(config) ++
+        port_cd_opts(config)
+
+    Stream.resource(
+      fn ->
+        Port.open({:spawn_executable, config.binary}, port_opts)
+      end,
+      fn port ->
+        receive do
+          {^port, {:data, {:eol, line}}} ->
+            case JsonLineEvent.parse(line) do
+              {:ok, event} -> {[event], port}
+              {:error, _} -> {[], port}
+            end
+
+          {^port, {:data, {:noeol, _partial}}} ->
+            {[], port}
+
+          {^port, {:exit_status, _code}} ->
+            {:halt, port}
+        after
+          300_000 -> {:halt, port}
+        end
+      end,
+      fn port ->
+        send(port, {self(), :close})
+
+        receive do
+          {^port, :closed} -> :ok
+        after
+          5_000 -> :ok
+        end
+      end
+    )
+  end
+
   # --- Command behaviour ---
 
   @impl Command
@@ -219,4 +301,12 @@ defmodule CodexWrapper.Exec do
   defp format_approval_policy(:on_failure), do: "on-failure"
   defp format_approval_policy(:on_request), do: "on-request"
   defp format_approval_policy(:never), do: "never"
+
+  # --- Port helpers ---
+
+  defp port_env_opts(%Config{env: []}), do: []
+  defp port_env_opts(%Config{env: env}), do: [{:env, env}]
+
+  defp port_cd_opts(%Config{working_dir: nil}), do: []
+  defp port_cd_opts(%Config{working_dir: dir}), do: [{:cd, String.to_charlist(dir)}]
 end

--- a/lib/codex_wrapper/json_line_event.ex
+++ b/lib/codex_wrapper/json_line_event.ex
@@ -1,0 +1,70 @@
+defmodule CodexWrapper.JsonLineEvent do
+  @moduledoc """
+  A single event from codex's `--json` NDJSON output.
+
+  When using `--json`, the codex CLI emits one JSON object per line.
+  Each event has an event type and associated data.
+
+  ## Event types
+
+  Common event types include:
+  - `"thread.started"` — thread initialization
+  - `"turn.started"` — turn began
+  - `"item.completed"` — item completed
+  - `"turn.completed"` — turn finished
+  """
+
+  @type t :: %__MODULE__{
+          event_type: String.t() | nil,
+          data: map(),
+          raw: String.t()
+        }
+
+  defstruct [:event_type, :raw, data: %{}]
+
+  @doc """
+  Parse a single NDJSON line into a `%JsonLineEvent{}`.
+  """
+  @spec parse(String.t()) :: {:ok, t()} | {:error, term()}
+  def parse(line) when is_binary(line) do
+    case Jason.decode(line) do
+      {:ok, data} when is_map(data) ->
+        {:ok,
+         %__MODULE__{
+           event_type: data["type"],
+           data: data,
+           raw: line
+         }}
+
+      {:ok, _other} ->
+        {:error, :not_an_object}
+
+      {:error, reason} ->
+        {:error, {:json_decode, reason}}
+    end
+  end
+
+  @doc """
+  Return the event type string.
+  """
+  @spec event_type(t()) :: String.t() | nil
+  def event_type(%__MODULE__{event_type: type}), do: type
+
+  @doc """
+  Return the full data map.
+  """
+  @spec data(t()) :: map()
+  def data(%__MODULE__{data: data}), do: data
+
+  @doc """
+  Get a value from the data map by key.
+  """
+  @spec get(t(), String.t(), term()) :: term()
+  def get(%__MODULE__{data: data}, key, default \\ nil), do: Map.get(data, key, default)
+
+  @doc """
+  Whether this event matches the given type.
+  """
+  @spec type?(t(), String.t()) :: boolean()
+  def type?(%__MODULE__{event_type: type}, expected), do: type == expected
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,8 +21,7 @@ defmodule CodexWrapperEx.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+      {:jason, "~> 1.4"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,3 @@
+%{
+  "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
+}

--- a/test/codex_wrapper/json_line_event_test.exs
+++ b/test/codex_wrapper/json_line_event_test.exs
@@ -1,0 +1,90 @@
+defmodule CodexWrapper.JsonLineEventTest do
+  use ExUnit.Case, async: true
+
+  alias CodexWrapper.JsonLineEvent
+
+  describe "parse/1" do
+    test "parses a valid NDJSON line with type" do
+      line = ~s({"type":"thread.started","thread_id":"abc123"})
+      assert {:ok, event} = JsonLineEvent.parse(line)
+      assert event.event_type == "thread.started"
+      assert event.data["thread_id"] == "abc123"
+      assert event.raw == line
+    end
+
+    test "parses a line without type field" do
+      line = ~s({"foo":"bar"})
+      assert {:ok, event} = JsonLineEvent.parse(line)
+      assert event.event_type == nil
+      assert event.data["foo"] == "bar"
+    end
+
+    test "returns error for non-object JSON" do
+      assert {:error, :not_an_object} = JsonLineEvent.parse("[1,2,3]")
+    end
+
+    test "returns error for invalid JSON" do
+      assert {:error, {:json_decode, _}} = JsonLineEvent.parse("not json")
+    end
+
+    test "parses multiple event types" do
+      lines = [
+        ~s({"type":"thread.started","thread_id":"t1"}),
+        ~s({"type":"turn.started","turn_id":"u1"}),
+        ~s({"type":"item.completed","item":{"id":"i1"}}),
+        ~s({"type":"turn.completed","turn_id":"u1"})
+      ]
+
+      events =
+        Enum.map(lines, fn line ->
+          {:ok, event} = JsonLineEvent.parse(line)
+          event
+        end)
+
+      assert Enum.map(events, & &1.event_type) == [
+               "thread.started",
+               "turn.started",
+               "item.completed",
+               "turn.completed"
+             ]
+    end
+  end
+
+  describe "accessor functions" do
+    setup do
+      line = ~s({"type":"item.completed","item":{"id":"i1"},"session_id":"s1"})
+      {:ok, event} = JsonLineEvent.parse(line)
+      %{event: event}
+    end
+
+    test "event_type/1", %{event: event} do
+      assert JsonLineEvent.event_type(event) == "item.completed"
+    end
+
+    test "data/1", %{event: event} do
+      data = JsonLineEvent.data(event)
+      assert data["type"] == "item.completed"
+      assert data["session_id"] == "s1"
+    end
+
+    test "get/2 returns value for existing key", %{event: event} do
+      assert JsonLineEvent.get(event, "session_id") == "s1"
+    end
+
+    test "get/2 returns nil for missing key", %{event: event} do
+      assert JsonLineEvent.get(event, "missing") == nil
+    end
+
+    test "get/3 returns default for missing key", %{event: event} do
+      assert JsonLineEvent.get(event, "missing", "default") == "default"
+    end
+
+    test "type?/2 returns true for matching type", %{event: event} do
+      assert JsonLineEvent.type?(event, "item.completed")
+    end
+
+    test "type?/2 returns false for non-matching type", %{event: event} do
+      refute JsonLineEvent.type?(event, "turn.started")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `JsonLineEvent` struct with parsing and accessor functions for NDJSON output from Codex CLI
- Add `execute_json/2` to collect all NDJSON events from a Codex execution
- Add `stream/2` for lazy Port-based streaming of Codex NDJSON output
- Add `jason ~> 1.4` dependency for JSON parsing

## Files changed
- `lib/codex_wrapper/json_line_event.ex` — New `JsonLineEvent` struct with `parse/1`, `event_type/1`, `data/1`, `get/2,3`, `type?/2`
- `lib/codex_wrapper/exec.ex` — Added `execute_json/2` and `stream/2` functions
- `lib/codex_wrapper.ex` — Added `exec_json/2` and `stream/2` convenience wrappers
- `mix.exs` — Added `jason ~> 1.4` dependency
- `test/codex_wrapper/json_line_event_test.exs` — 12 tests for parsing and accessors

## Test plan
- [x] 59 tests pass locally (`mix test`)
- [x] Compiles cleanly with `--warnings-as-errors`
- [ ] CI passes

Closes #3