### PR TITLE
feat(review): add Review command with builder and convenience API

### DIFF
--- a/lib/codex_wrapper.ex
+++ b/lib/codex_wrapper.ex
@@ -25,7 +25,7 @@ defmodule CodexWrapper do
   3. System PATH lookup
   """
 
-  alias CodexWrapper.{Config, Exec, JsonLineEvent, Result}
+  alias CodexWrapper.{Config, Exec, JsonLineEvent, Result, Review}
 
   @doc """
   Run an arbitrary CLI command that isn't wrapped by a dedicated module.
@@ -128,12 +128,81 @@ defmodule CodexWrapper do
     Exec.stream(exec, config)
   end
 
+  @doc """
+  Run a code review via `codex exec review`.
+
+  Convenience wrapper that builds a `Config` and `Review` from keyword options.
+  Returns `{:ok, %Result{}}` on success or `{:error, reason}` on failure.
+
+  ## Options
+
+  Config options (passed to `Config.new/1`):
+    * `:binary` - Path to codex binary
+    * `:working_dir` - Working directory
+    * `:env` - Environment variables
+    * `:timeout` - Timeout in ms
+    * `:verbose` - Enable verbose output
+
+  Review options (passed to `Review` builder):
+    * `:prompt` - Additional review context
+    * `:uncommitted` - Review uncommitted changes (boolean)
+    * `:base` - Compare against base branch
+    * `:commit` - Review a specific commit
+    * `:title` - PR/review title
+    * `:model` - Model name
+    * `:full_auto` - Enable full-auto (boolean)
+    * `:dangerously_bypass_approvals_and_sandbox` - Bypass all (boolean)
+    * `:skip_git_repo_check` - Skip git check (boolean)
+    * `:ephemeral` - Ephemeral mode (boolean)
+    * `:json` - JSON output (boolean)
+    * `:output_last_message` - Output last message path
+
+  ## Examples
+
+      CodexWrapper.review(uncommitted: true, working_dir: "/path/to/repo")
+      CodexWrapper.review(base: "main", model: "o3")
+  """
+  @spec review(keyword()) :: {:ok, Result.t()} | {:error, term()}
+  def review(opts \\ []) do
+    {config_opts, review_opts} = split_opts(opts)
+    config = Config.new(config_opts)
+    review = build_review(review_opts)
+    Review.execute(review, config)
+  end
+
   # --- Private ---
 
   @config_keys [:binary, :working_dir, :env, :timeout, :verbose]
 
   defp split_opts(opts) do
     Enum.split_with(opts, fn {k, _v} -> k in @config_keys end)
+  end
+
+  defp build_review(opts) do
+    review = Review.new()
+
+    Enum.reduce(opts, review, fn
+      {:prompt, v}, r -> Review.prompt(r, v)
+      {:uncommitted, true}, r -> Review.uncommitted(r)
+      {:uncommitted, false}, r -> r
+      {:base, v}, r -> Review.base(r, v)
+      {:commit, v}, r -> Review.commit(r, v)
+      {:title, v}, r -> Review.title(r, v)
+      {:model, v}, r -> Review.model(r, v)
+      {:full_auto, true}, r -> Review.full_auto(r)
+      {:full_auto, false}, r -> r
+      {:dangerously_bypass_approvals_and_sandbox, true}, r ->
+        Review.dangerously_bypass_approvals_and_sandbox(r)
+      {:dangerously_bypass_approvals_and_sandbox, false}, r -> r
+      {:skip_git_repo_check, true}, r -> Review.skip_git_repo_check(r)
+      {:skip_git_repo_check, false}, r -> r
+      {:ephemeral, true}, r -> Review.ephemeral(r)
+      {:ephemeral, false}, r -> r
+      {:json, true}, r -> Review.json(r)
+      {:json, false}, r -> r
+      {:output_last_message, v}, r -> Review.output_last_message(r, v)
+      _other, r -> r
+    end)
   end
 
   defp build_exec(prompt, opts) do

--- a/lib/codex_wrapper/review.ex
+++ b/lib/codex_wrapper/review.ex
@@ -1,0 +1,283 @@
+defmodule CodexWrapper.Review do
+  @moduledoc """
+  Review command — code review with git integration.
+
+  Wraps `codex exec review` with review-specific CLI flags.
+
+  ## Usage
+
+      config = CodexWrapper.Config.new(working_dir: "/path/to/repo")
+
+      # Review uncommitted changes
+      review = CodexWrapper.Review.new()
+        |> CodexWrapper.Review.uncommitted()
+        |> CodexWrapper.Review.model("o3")
+
+      {:ok, result} = CodexWrapper.Review.execute(review, config)
+
+      # Review against a base branch
+      CodexWrapper.Review.new()
+      |> CodexWrapper.Review.base("main")
+      |> CodexWrapper.Review.execute(config)
+
+      # Review a specific commit
+      CodexWrapper.Review.new()
+      |> CodexWrapper.Review.commit("abc123")
+      |> CodexWrapper.Review.execute(config)
+  """
+
+  @behaviour CodexWrapper.Command
+
+  alias CodexWrapper.{Command, Config, JsonLineEvent, Result}
+
+  @type t :: %__MODULE__{
+          prompt: String.t() | nil,
+          uncommitted: boolean(),
+          base: String.t() | nil,
+          commit: String.t() | nil,
+          title: String.t() | nil,
+          model: String.t() | nil,
+          full_auto: boolean(),
+          dangerously_bypass_approvals_and_sandbox: boolean(),
+          skip_git_repo_check: boolean(),
+          ephemeral: boolean(),
+          json: boolean(),
+          output_last_message: String.t() | nil,
+          config_overrides: [String.t()],
+          enabled_features: [String.t()],
+          disabled_features: [String.t()]
+        }
+
+  defstruct [
+    :prompt,
+    :base,
+    :commit,
+    :title,
+    :model,
+    :output_last_message,
+    uncommitted: false,
+    full_auto: false,
+    dangerously_bypass_approvals_and_sandbox: false,
+    skip_git_repo_check: false,
+    ephemeral: false,
+    json: false,
+    config_overrides: [],
+    enabled_features: [],
+    disabled_features: []
+  ]
+
+  # --- Constructor ---
+
+  @doc """
+  Create a new review command.
+  """
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  # --- Builder functions ---
+
+  @doc "Set an optional prompt for additional review context."
+  @spec prompt(t(), String.t()) :: t()
+  def prompt(%__MODULE__{} = r, prompt), do: %{r | prompt: prompt}
+
+  @doc "Review uncommitted changes."
+  @spec uncommitted(t()) :: t()
+  def uncommitted(%__MODULE__{} = r), do: %{r | uncommitted: true}
+
+  @doc "Compare against a base branch."
+  @spec base(t(), String.t()) :: t()
+  def base(%__MODULE__{} = r, branch), do: %{r | base: branch}
+
+  @doc "Review a specific commit."
+  @spec commit(t(), String.t()) :: t()
+  def commit(%__MODULE__{} = r, sha), do: %{r | commit: sha}
+
+  @doc "Set the PR/review title."
+  @spec title(t(), String.t()) :: t()
+  def title(%__MODULE__{} = r, title), do: %{r | title: title}
+
+  @doc "Set the model."
+  @spec model(t(), String.t()) :: t()
+  def model(%__MODULE__{} = r, model), do: %{r | model: model}
+
+  @doc "Enable full-auto mode."
+  @spec full_auto(t()) :: t()
+  def full_auto(%__MODULE__{} = r), do: %{r | full_auto: true}
+
+  @doc "Bypass all approvals and sandbox. Use with extreme caution."
+  @spec dangerously_bypass_approvals_and_sandbox(t()) :: t()
+  def dangerously_bypass_approvals_and_sandbox(%__MODULE__{} = r),
+    do: %{r | dangerously_bypass_approvals_and_sandbox: true}
+
+  @doc "Skip the git repo check."
+  @spec skip_git_repo_check(t()) :: t()
+  def skip_git_repo_check(%__MODULE__{} = r), do: %{r | skip_git_repo_check: true}
+
+  @doc "Enable ephemeral mode (no session persistence)."
+  @spec ephemeral(t()) :: t()
+  def ephemeral(%__MODULE__{} = r), do: %{r | ephemeral: true}
+
+  @doc "Enable JSON output."
+  @spec json(t()) :: t()
+  def json(%__MODULE__{} = r), do: %{r | json: true}
+
+  @doc "Set the output-last-message path."
+  @spec output_last_message(t(), String.t()) :: t()
+  def output_last_message(%__MODULE__{} = r, path), do: %{r | output_last_message: path}
+
+  @doc "Add a config override (key=value)."
+  @spec config(t(), String.t()) :: t()
+  def config(%__MODULE__{} = r, kv), do: %{r | config_overrides: r.config_overrides ++ [kv]}
+
+  @doc "Enable a feature."
+  @spec enable(t(), String.t()) :: t()
+  def enable(%__MODULE__{} = r, feature),
+    do: %{r | enabled_features: r.enabled_features ++ [feature]}
+
+  @doc "Disable a feature."
+  @spec disable(t(), String.t()) :: t()
+  def disable(%__MODULE__{} = r, feature),
+    do: %{r | disabled_features: r.disabled_features ++ [feature]}
+
+  # --- Execution ---
+
+  @doc """
+  Execute the review command synchronously, returning a parsed `%Result{}`.
+  """
+  @spec execute(t(), Config.t()) :: {:ok, Result.t()} | {:error, term()}
+  def execute(%__MODULE__{} = review, %Config{} = config) do
+    Command.run(__MODULE__, review, config)
+  end
+
+  @doc """
+  Execute the review command with `--json` and return parsed NDJSON events.
+
+  Forces `--json` on the command, runs synchronously, then parses
+  each NDJSON line from stdout.
+  """
+  @spec execute_json(t(), Config.t()) :: {:ok, [JsonLineEvent.t()]} | {:error, term()}
+  def execute_json(%__MODULE__{} = review, %Config{} = config) do
+    review = %{review | json: true}
+
+    case execute(review, config) do
+      {:ok, result} ->
+        events =
+          result.stdout
+          |> String.split("\n", trim: true)
+          |> Enum.filter(&String.starts_with?(String.trim_leading(&1), "{"))
+          |> Enum.flat_map(fn line ->
+            case JsonLineEvent.parse(line) do
+              {:ok, event} -> [event]
+              {:error, _} -> []
+            end
+          end)
+
+        {:ok, events}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  @doc """
+  Execute the review command and return a lazy `Stream` of `%JsonLineEvent{}`.
+
+  Uses a Port with `:line` mode to read NDJSON output line-by-line.
+  Forces `--json` on the command.
+  """
+  @spec stream(t(), Config.t()) :: Enumerable.t()
+  def stream(%__MODULE__{} = review, %Config{} = config) do
+    review = %{review | json: true}
+    args = Config.base_args(config) ++ args(review)
+
+    port_opts =
+      [:binary, :exit_status, {:line, 1_048_576}, {:args, args}] ++
+        port_env_opts(config) ++
+        port_cd_opts(config)
+
+    Stream.resource(
+      fn ->
+        Port.open({:spawn_executable, config.binary}, port_opts)
+      end,
+      fn port ->
+        receive do
+          {^port, {:data, {:eol, line}}} ->
+            case JsonLineEvent.parse(line) do
+              {:ok, event} -> {[event], port}
+              {:error, _} -> {[], port}
+            end
+
+          {^port, {:data, {:noeol, _partial}}} ->
+            {[], port}
+
+          {^port, {:exit_status, _code}} ->
+            {:halt, port}
+        after
+          300_000 -> {:halt, port}
+        end
+      end,
+      fn port ->
+        send(port, {self(), :close})
+
+        receive do
+          {^port, :closed} -> :ok
+        after
+          5_000 -> :ok
+        end
+      end
+    )
+  end
+
+  # --- Command behaviour ---
+
+  @impl Command
+  def args(%__MODULE__{} = r) do
+    ["exec", "review"]
+    |> add_list("-c", r.config_overrides)
+    |> add_list("--enable", r.enabled_features)
+    |> add_list("--disable", r.disabled_features)
+    |> add_bool("--uncommitted", r.uncommitted)
+    |> add_opt("--base", r.base)
+    |> add_opt("--commit", r.commit)
+    |> add_opt("--model", r.model)
+    |> add_opt("--title", r.title)
+    |> add_bool("--full-auto", r.full_auto)
+    |> add_bool("--dangerously-bypass-approvals-and-sandbox",
+         r.dangerously_bypass_approvals_and_sandbox)
+    |> add_bool("--skip-git-repo-check", r.skip_git_repo_check)
+    |> add_bool("--ephemeral", r.ephemeral)
+    |> add_bool("--json", r.json)
+    |> add_opt("--output-last-message", r.output_last_message)
+    |> add_prompt(r.prompt)
+  end
+
+  @impl Command
+  def parse_output(stdout, exit_code) do
+    result = Result.from_cmd({stdout, exit_code})
+
+    if result.success do
+      {:ok, result}
+    else
+      {:ok, result}
+    end
+  end
+
+  # --- Arg helpers ---
+
+  defp add_prompt(args, nil), do: args
+  defp add_prompt(args, prompt), do: args ++ [prompt]
+  defp add_opt(args, _flag, nil), do: args
+  defp add_opt(args, flag, value), do: args ++ [flag, value]
+  defp add_bool(args, _flag, false), do: args
+  defp add_bool(args, flag, true), do: args ++ [flag]
+  defp add_list(args, _flag, []), do: args
+  defp add_list(args, flag, values), do: args ++ Enum.flat_map(values, &[flag, &1])
+
+  # --- Port helpers ---
+
+  defp port_env_opts(%Config{env: []}), do: []
+  defp port_env_opts(%Config{env: env}), do: [{:env, env}]
+
+  defp port_cd_opts(%Config{working_dir: nil}), do: []
+  defp port_cd_opts(%Config{working_dir: dir}), do: [{:cd, String.to_charlist(dir)}]
+end

--- a/test/codex_wrapper/review_test.exs
+++ b/test/codex_wrapper/review_test.exs
@@ -1,0 +1,236 @@
+defmodule CodexWrapper.ReviewTest do
+  use ExUnit.Case, async: true
+
+  alias CodexWrapper.Review
+
+  describe "new/0" do
+    test "defaults" do
+      review = Review.new()
+      assert review.prompt == nil
+      assert review.uncommitted == false
+      assert review.base == nil
+      assert review.commit == nil
+      assert review.title == nil
+      assert review.model == nil
+      assert review.full_auto == false
+      assert review.dangerously_bypass_approvals_and_sandbox == false
+      assert review.skip_git_repo_check == false
+      assert review.ephemeral == false
+      assert review.json == false
+      assert review.output_last_message == nil
+      assert review.config_overrides == []
+      assert review.enabled_features == []
+      assert review.disabled_features == []
+    end
+  end
+
+  describe "builder functions" do
+    test "prompt/2" do
+      review = Review.new() |> Review.prompt("focus on correctness")
+      assert review.prompt == "focus on correctness"
+    end
+
+    test "uncommitted/1" do
+      review = Review.new() |> Review.uncommitted()
+      assert review.uncommitted == true
+    end
+
+    test "base/2" do
+      review = Review.new() |> Review.base("main")
+      assert review.base == "main"
+    end
+
+    test "commit/2" do
+      review = Review.new() |> Review.commit("abc123")
+      assert review.commit == "abc123"
+    end
+
+    test "title/2" do
+      review = Review.new() |> Review.title("Fix auth bug")
+      assert review.title == "Fix auth bug"
+    end
+
+    test "model/2" do
+      review = Review.new() |> Review.model("o3")
+      assert review.model == "o3"
+    end
+
+    test "full_auto/1" do
+      review = Review.new() |> Review.full_auto()
+      assert review.full_auto == true
+    end
+
+    test "dangerously_bypass_approvals_and_sandbox/1" do
+      review = Review.new() |> Review.dangerously_bypass_approvals_and_sandbox()
+      assert review.dangerously_bypass_approvals_and_sandbox == true
+    end
+
+    test "skip_git_repo_check/1" do
+      review = Review.new() |> Review.skip_git_repo_check()
+      assert review.skip_git_repo_check == true
+    end
+
+    test "ephemeral/1" do
+      review = Review.new() |> Review.ephemeral()
+      assert review.ephemeral == true
+    end
+
+    test "json/1" do
+      review = Review.new() |> Review.json()
+      assert review.json == true
+    end
+
+    test "output_last_message/2" do
+      review = Review.new() |> Review.output_last_message("/tmp/msg.json")
+      assert review.output_last_message == "/tmp/msg.json"
+    end
+
+    test "config/2 accumulates" do
+      review = Review.new() |> Review.config("key=val") |> Review.config("k2=v2")
+      assert review.config_overrides == ["key=val", "k2=v2"]
+    end
+
+    test "enable/2 accumulates" do
+      review = Review.new() |> Review.enable("feat1") |> Review.enable("feat2")
+      assert review.enabled_features == ["feat1", "feat2"]
+    end
+
+    test "disable/2 accumulates" do
+      review = Review.new() |> Review.disable("feat1")
+      assert review.disabled_features == ["feat1"]
+    end
+  end
+
+  describe "args/1" do
+    test "minimal args" do
+      args = Review.new() |> Review.args()
+      assert args == ["exec", "review"]
+    end
+
+    test "uncommitted with model and json matches Rust ordering" do
+      args =
+        Review.new()
+        |> Review.uncommitted()
+        |> Review.model("gpt-5")
+        |> Review.json()
+        |> Review.prompt("focus on correctness")
+        |> Review.args()
+
+      assert args == [
+               "exec",
+               "review",
+               "--uncommitted",
+               "--model", "gpt-5",
+               "--json",
+               "focus on correctness"
+             ]
+    end
+
+    test "base branch comparison" do
+      args =
+        Review.new()
+        |> Review.base("main")
+        |> Review.model("o3")
+        |> Review.args()
+
+      assert args == ["exec", "review", "--base", "main", "--model", "o3"]
+    end
+
+    test "specific commit review" do
+      args =
+        Review.new()
+        |> Review.commit("abc123")
+        |> Review.args()
+
+      assert args == ["exec", "review", "--commit", "abc123"]
+    end
+
+    test "config overrides come first" do
+      args =
+        Review.new()
+        |> Review.config("key=val")
+        |> Review.model("o3")
+        |> Review.args()
+
+      config_idx = Enum.find_index(args, &(&1 == "-c"))
+      model_idx = Enum.find_index(args, &(&1 == "--model"))
+      assert config_idx < model_idx
+    end
+
+    test "list flags repeat" do
+      args =
+        Review.new()
+        |> Review.enable("feat1")
+        |> Review.enable("feat2")
+        |> Review.disable("feat3")
+        |> Review.args()
+
+      assert "--enable" in args
+      assert "feat1" in args
+      assert "feat2" in args
+      assert "--disable" in args
+      assert "feat3" in args
+    end
+
+    test "boolean flags" do
+      args =
+        Review.new()
+        |> Review.full_auto()
+        |> Review.dangerously_bypass_approvals_and_sandbox()
+        |> Review.skip_git_repo_check()
+        |> Review.ephemeral()
+        |> Review.args()
+
+      assert "--full-auto" in args
+      assert "--dangerously-bypass-approvals-and-sandbox" in args
+      assert "--skip-git-repo-check" in args
+      assert "--ephemeral" in args
+    end
+
+    test "title flag" do
+      args =
+        Review.new()
+        |> Review.title("Fix auth bug")
+        |> Review.args()
+
+      idx = Enum.find_index(args, &(&1 == "--title"))
+      assert Enum.at(args, idx + 1) == "Fix auth bug"
+    end
+
+    test "prompt is always last when present" do
+      args =
+        Review.new()
+        |> Review.model("o3")
+        |> Review.json()
+        |> Review.prompt("the prompt")
+        |> Review.args()
+
+      assert List.last(args) == "the prompt"
+    end
+
+    test "no prompt appended when nil" do
+      args =
+        Review.new()
+        |> Review.uncommitted()
+        |> Review.args()
+
+      assert args == ["exec", "review", "--uncommitted"]
+    end
+  end
+
+  describe "parse_output/2" do
+    test "returns result for exit code 0" do
+      assert {:ok, result} = Review.parse_output("review output\n", 0)
+      assert result.stdout == "review output\n"
+      assert result.exit_code == 0
+      assert result.success == true
+    end
+
+    test "returns result for non-zero exit code" do
+      assert {:ok, result} = Review.parse_output("error\n", 1)
+      assert result.stdout == "error\n"
+      assert result.exit_code == 1
+      assert result.success == false
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `CodexWrapper.Review` struct implementing the `Command` behaviour with builder pattern, `execute/2`, `execute_json/2`, and `stream/2`
- Args build `["exec", "review", ...]` matching the Rust codex-wrapper ordering
- Add `CodexWrapper.review/1` convenience function with `build_review/1` that splits config/review opts and reduces through the builder
- Comprehensive test coverage for defaults, all builder functions, arg building (ordering, lists, booleans, optional prompt), and `parse_output/2`

## Files changed
- `lib/codex_wrapper/review.ex` — New `CodexWrapper.Review` struct with builder pattern and Command behaviour implementation
- `test/codex_wrapper/review_test.exs` — Tests for review command (defaults, builders, arg ordering, parse_output)
- `lib/codex_wrapper.ex` — Added `review/1` convenience function

## Test plan
- [x] Tests pass locally (87 tests, 0 failures)
- [x] Compiles with no warnings (`mix compile --warnings-as-errors`)
- [ ] CI passes

Closes #4