### PR TITLE
feat: Session and SessionServer for multi-turn

### DIFF
--- a/lib/codex_wrapper/exec_resume.ex
+++ b/lib/codex_wrapper/exec_resume.ex
@@ -1,0 +1,281 @@
+defmodule CodexWrapper.ExecResume do
+  @moduledoc """
+  ExecResume command — resume an existing session non-interactively.
+
+  Wraps `codex exec resume [session_id] [prompt]` with the full set of CLI flags.
+
+  ## Usage
+
+      config = CodexWrapper.Config.new(working_dir: "/path/to/project")
+
+      # Resume the most recent session
+      exec = CodexWrapper.ExecResume.new()
+        |> CodexWrapper.ExecResume.last()
+        |> CodexWrapper.ExecResume.prompt("continue with tests")
+
+      {:ok, result} = CodexWrapper.ExecResume.execute(exec, config)
+
+      # Resume a specific session by ID
+      exec = CodexWrapper.ExecResume.new()
+        |> CodexWrapper.ExecResume.session_id("abc-123")
+        |> CodexWrapper.ExecResume.prompt("add error handling")
+
+      {:ok, result} = CodexWrapper.ExecResume.execute(exec, config)
+  """
+
+  @behaviour CodexWrapper.Command
+
+  alias CodexWrapper.{Command, Config, JsonLineEvent, Result}
+
+  @type t :: %__MODULE__{
+          session_id: String.t() | nil,
+          prompt: String.t() | nil,
+          last: boolean(),
+          all: boolean(),
+          model: String.t() | nil,
+          full_auto: boolean(),
+          dangerously_bypass_approvals_and_sandbox: boolean(),
+          skip_git_repo_check: boolean(),
+          ephemeral: boolean(),
+          json: boolean(),
+          output_last_message: String.t() | nil,
+          images: [String.t()],
+          config_overrides: [String.t()],
+          enabled_features: [String.t()],
+          disabled_features: [String.t()]
+        }
+
+  defstruct [
+    :session_id,
+    :prompt,
+    :model,
+    :output_last_message,
+    last: false,
+    all: false,
+    full_auto: false,
+    dangerously_bypass_approvals_and_sandbox: false,
+    skip_git_repo_check: false,
+    ephemeral: false,
+    json: false,
+    images: [],
+    config_overrides: [],
+    enabled_features: [],
+    disabled_features: []
+  ]
+
+  # --- Constructor ---
+
+  @doc """
+  Create a new exec resume command.
+  """
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  # --- Builder functions ---
+
+  @doc "Set the session ID to resume."
+  @spec session_id(t(), String.t()) :: t()
+  def session_id(%__MODULE__{} = e, id), do: %{e | session_id: id}
+
+  @doc "Set the continuation prompt."
+  @spec prompt(t(), String.t()) :: t()
+  def prompt(%__MODULE__{} = e, prompt), do: %{e | prompt: prompt}
+
+  @doc "Resume the most recent session."
+  @spec last(t()) :: t()
+  def last(%__MODULE__{} = e), do: %{e | last: true}
+
+  @doc "Show all sessions (disables cwd filtering)."
+  @spec all(t()) :: t()
+  def all(%__MODULE__{} = e), do: %{e | all: true}
+
+  @doc "Set the model."
+  @spec model(t(), String.t()) :: t()
+  def model(%__MODULE__{} = e, model), do: %{e | model: model}
+
+  @doc "Enable full-auto mode."
+  @spec full_auto(t()) :: t()
+  def full_auto(%__MODULE__{} = e), do: %{e | full_auto: true}
+
+  @doc "Bypass all approvals and sandbox. Use with extreme caution."
+  @spec dangerously_bypass_approvals_and_sandbox(t()) :: t()
+  def dangerously_bypass_approvals_and_sandbox(%__MODULE__{} = e),
+    do: %{e | dangerously_bypass_approvals_and_sandbox: true}
+
+  @doc "Skip the git repo check."
+  @spec skip_git_repo_check(t()) :: t()
+  def skip_git_repo_check(%__MODULE__{} = e), do: %{e | skip_git_repo_check: true}
+
+  @doc "Enable ephemeral mode (no session persistence)."
+  @spec ephemeral(t()) :: t()
+  def ephemeral(%__MODULE__{} = e), do: %{e | ephemeral: true}
+
+  @doc "Enable JSON output."
+  @spec json(t()) :: t()
+  def json(%__MODULE__{} = e), do: %{e | json: true}
+
+  @doc "Set the output-last-message path."
+  @spec output_last_message(t(), String.t()) :: t()
+  def output_last_message(%__MODULE__{} = e, path), do: %{e | output_last_message: path}
+
+  @doc "Add an image path."
+  @spec image(t(), String.t()) :: t()
+  def image(%__MODULE__{} = e, path), do: %{e | images: e.images ++ [path]}
+
+  @doc "Add a config override (key=value)."
+  @spec config(t(), String.t()) :: t()
+  def config(%__MODULE__{} = e, kv), do: %{e | config_overrides: e.config_overrides ++ [kv]}
+
+  @doc "Enable a feature."
+  @spec enable(t(), String.t()) :: t()
+  def enable(%__MODULE__{} = e, feature),
+    do: %{e | enabled_features: e.enabled_features ++ [feature]}
+
+  @doc "Disable a feature."
+  @spec disable(t(), String.t()) :: t()
+  def disable(%__MODULE__{} = e, feature),
+    do: %{e | disabled_features: e.disabled_features ++ [feature]}
+
+  # --- Execution ---
+
+  @doc """
+  Execute the command synchronously, returning a parsed `%Result{}`.
+  """
+  @spec execute(t(), Config.t()) :: {:ok, Result.t()} | {:error, term()}
+  def execute(%__MODULE__{} = exec, %Config{} = config) do
+    Command.run(__MODULE__, exec, config)
+  end
+
+  @doc """
+  Execute the command with `--json` and return a list of parsed `%JsonLineEvent{}`.
+
+  Forces `--json` on the command, runs synchronously, then parses
+  each NDJSON line from stdout.
+  """
+  @spec execute_json(t(), Config.t()) :: {:ok, [JsonLineEvent.t()]} | {:error, term()}
+  def execute_json(%__MODULE__{} = exec, %Config{} = config) do
+    exec = %{exec | json: true}
+
+    case execute(exec, config) do
+      {:ok, result} ->
+        events =
+          result.stdout
+          |> String.split("\n", trim: true)
+          |> Enum.filter(&String.starts_with?(String.trim_leading(&1), "{"))
+          |> Enum.flat_map(fn line ->
+            case JsonLineEvent.parse(line) do
+              {:ok, event} -> [event]
+              {:error, _} -> []
+            end
+          end)
+
+        {:ok, events}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  @doc """
+  Execute the command and return a lazy `Stream` of `%JsonLineEvent{}`.
+
+  Forces `--json` on the command. Uses a Port with `:line` mode.
+  """
+  @spec stream(t(), Config.t()) :: Enumerable.t()
+  def stream(%__MODULE__{} = exec, %Config{} = config) do
+    exec = %{exec | json: true}
+    args = Config.base_args(config) ++ args(exec)
+
+    port_opts =
+      [:binary, :exit_status, {:line, 1_048_576}, {:args, args}] ++
+        port_env_opts(config) ++
+        port_cd_opts(config)
+
+    Stream.resource(
+      fn ->
+        Port.open({:spawn_executable, config.binary}, port_opts)
+      end,
+      fn port ->
+        receive do
+          {^port, {:data, {:eol, line}}} ->
+            case JsonLineEvent.parse(line) do
+              {:ok, event} -> {[event], port}
+              {:error, _} -> {[], port}
+            end
+
+          {^port, {:data, {:noeol, _partial}}} ->
+            {[], port}
+
+          {^port, {:exit_status, _code}} ->
+            {:halt, port}
+        after
+          300_000 -> {:halt, port}
+        end
+      end,
+      fn port ->
+        send(port, {self(), :close})
+
+        receive do
+          {^port, :closed} -> :ok
+        after
+          5_000 -> :ok
+        end
+      end
+    )
+  end
+
+  # --- Command behaviour ---
+
+  @impl Command
+  def args(%__MODULE__{} = e) do
+    ["exec", "resume"]
+    |> add_list("-c", e.config_overrides)
+    |> add_list("--enable", e.enabled_features)
+    |> add_list("--disable", e.disabled_features)
+    |> add_bool("--last", e.last)
+    |> add_bool("--all", e.all)
+    |> add_list("--image", e.images)
+    |> add_opt("--model", e.model)
+    |> add_bool("--full-auto", e.full_auto)
+    |> add_bool(
+      "--dangerously-bypass-approvals-and-sandbox",
+      e.dangerously_bypass_approvals_and_sandbox
+    )
+    |> add_bool("--skip-git-repo-check", e.skip_git_repo_check)
+    |> add_bool("--ephemeral", e.ephemeral)
+    |> add_bool("--json", e.json)
+    |> add_opt("--output-last-message", e.output_last_message)
+    |> add_opt_flag(e.session_id)
+    |> add_opt_flag(e.prompt)
+  end
+
+  @impl Command
+  def parse_output(stdout, exit_code) do
+    result = Result.from_cmd({stdout, exit_code})
+
+    if result.success do
+      {:ok, result}
+    else
+      {:ok, result}
+    end
+  end
+
+  # --- Arg helpers ---
+
+  defp add_opt_flag(args, nil), do: args
+  defp add_opt_flag(args, value), do: args ++ [value]
+  defp add_opt(args, _flag, nil), do: args
+  defp add_opt(args, flag, value), do: args ++ [flag, value]
+  defp add_bool(args, _flag, false), do: args
+  defp add_bool(args, flag, true), do: args ++ [flag]
+  defp add_list(args, _flag, []), do: args
+  defp add_list(args, flag, values), do: args ++ Enum.flat_map(values, &[flag, &1])
+
+  # --- Port helpers ---
+
+  defp port_env_opts(%Config{env: []}), do: []
+  defp port_env_opts(%Config{env: env}), do: [{:env, env}]
+
+  defp port_cd_opts(%Config{working_dir: nil}), do: []
+  defp port_cd_opts(%Config{working_dir: dir}), do: [{:cd, String.to_charlist(dir)}]
+end

--- a/lib/codex_wrapper/session.ex
+++ b/lib/codex_wrapper/session.ex
@@ -1,0 +1,259 @@
+defmodule CodexWrapper.Session do
+  @moduledoc """
+  Multi-turn session management.
+
+  Wraps repeated `Exec` / `ExecResume` calls, automatically threading the
+  `session_id` so each turn continues the same conversation.
+
+  The first turn uses `Exec` to create a new session. Subsequent turns
+  use `ExecResume` with the session ID extracted from the JSON output.
+
+  ## Usage
+
+      config = CodexWrapper.Config.new(working_dir: "/path/to/project")
+      session = CodexWrapper.Session.new(config)
+
+      {:ok, session, result} = CodexWrapper.Session.send(session, "What files are in this project?")
+      {:ok, session, result} = CodexWrapper.Session.send(session, "Now add tests for lib/foo.ex")
+
+      # Access history
+      CodexWrapper.Session.turns(session)
+      #=> [%Result{...}, %Result{...}]
+
+      # Resume a previous session
+      session = CodexWrapper.Session.resume(config, "session-id-abc")
+  """
+
+  alias CodexWrapper.{Config, Exec, ExecResume, JsonLineEvent, Result}
+
+  @type t :: %__MODULE__{
+          config: Config.t(),
+          session_id: String.t() | nil,
+          history: [Result.t()],
+          exec_opts: keyword()
+        }
+
+  defstruct [
+    :config,
+    :session_id,
+    history: [],
+    exec_opts: []
+  ]
+
+  @doc """
+  Create a new session with the given config.
+
+  ## Options
+
+  Any option accepted by `CodexWrapper.exec/2` (exec-level options only):
+
+    * `:model` - Model name
+    * `:sandbox` - Sandbox mode
+    * `:approval_policy` - Approval policy
+    * `:full_auto` - Enable full-auto (boolean)
+    * `:dangerously_bypass_approvals_and_sandbox` - Bypass all (boolean)
+    * `:skip_git_repo_check` - Skip git check (boolean)
+  """
+  @spec new(Config.t(), keyword()) :: t()
+  def new(%Config{} = config, opts \\ []) do
+    %__MODULE__{config: config, exec_opts: opts}
+  end
+
+  @doc """
+  Resume an existing session by ID.
+  """
+  @spec resume(Config.t(), String.t(), keyword()) :: t()
+  def resume(%Config{} = config, session_id, opts \\ []) do
+    %__MODULE__{config: config, session_id: session_id, exec_opts: opts}
+  end
+
+  @doc """
+  Send a message in the session. Returns the updated session and result.
+
+  The first turn creates a new session via `Exec`. Subsequent turns use
+  `ExecResume` with the session ID from the first result.
+
+  Internally uses `--json` to extract the session ID from NDJSON events.
+  """
+  @spec send(t(), String.t(), keyword()) :: {:ok, t(), Result.t()} | {:error, term()}
+  def send(%__MODULE__{} = session, prompt, opts \\ []) do
+    case execute_turn(session, prompt, opts) do
+      {:ok, result, events} ->
+        new_session_id = extract_session_id(events) || session.session_id
+
+        updated = %{
+          session
+          | session_id: new_session_id,
+            history: session.history ++ [result]
+        }
+
+        {:ok, updated, result}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Send a message and return a stream of events.
+
+  Returns `{updated_session, stream}`. The session_id is captured from
+  the stream, so consume the stream before sending the next message.
+  """
+  @spec stream(t(), String.t(), keyword()) :: {t(), Enumerable.t()}
+  def stream(%__MODULE__{} = session, prompt, opts \\ []) do
+    raw_stream = build_stream(session, prompt, opts)
+
+    session_ref = make_ref()
+    parent = self()
+
+    wrapped_stream =
+      Stream.each(raw_stream, &maybe_capture_session_id(&1, session_ref, parent))
+
+    {%{session | session_id: session_ref}, wrapped_stream}
+  end
+
+  @doc """
+  Get the session ID (if established).
+  """
+  @spec session_id(t()) :: String.t() | nil
+  def session_id(%__MODULE__{session_id: sid}) when is_binary(sid), do: sid
+  def session_id(%__MODULE__{}), do: nil
+
+  @doc """
+  Get the conversation history (list of results).
+  """
+  @spec turns(t()) :: [Result.t()]
+  def turns(%__MODULE__{history: history}), do: history
+
+  @doc """
+  Alias for `turns/1`.
+  """
+  @spec history(t()) :: [Result.t()]
+  def history(%__MODULE__{} = session), do: turns(session)
+
+  @doc """
+  Get the number of completed turns.
+  """
+  @spec turn_count(t()) :: non_neg_integer()
+  def turn_count(%__MODULE__{history: history}), do: length(history)
+
+  @doc """
+  Get the total cost across all turns.
+
+  Returns `0.0` as the Codex CLI does not currently expose per-turn cost.
+  This is provided for API compatibility with future cost reporting.
+  """
+  @spec total_cost(t()) :: float()
+  def total_cost(%__MODULE__{}), do: 0.0
+
+  @doc """
+  Get the last result, if any.
+  """
+  @spec last_result(t()) :: Result.t() | nil
+  def last_result(%__MODULE__{history: []}), do: nil
+  def last_result(%__MODULE__{history: history}), do: List.last(history)
+
+  # --- Private ---
+
+  defp execute_turn(%__MODULE__{session_id: nil} = session, prompt, per_call_opts) do
+    exec = build_exec(session, prompt, per_call_opts)
+
+    case Exec.execute_json(exec, session.config) do
+      {:ok, events} ->
+        result = events_to_result(events)
+        {:ok, result, events}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp execute_turn(%__MODULE__{session_id: sid} = session, prompt, per_call_opts)
+       when is_binary(sid) do
+    exec_resume = build_exec_resume(session, prompt, per_call_opts)
+
+    case ExecResume.execute_json(exec_resume, session.config) do
+      {:ok, events} ->
+        result = events_to_result(events)
+        {:ok, result, events}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp build_exec(session, prompt, per_call_opts) do
+    merged_opts = Keyword.merge(session.exec_opts, per_call_opts)
+    exec = Exec.new(prompt)
+
+    Enum.reduce(merged_opts, exec, fn
+      {:model, v}, e -> Exec.model(e, v)
+      {:sandbox, v}, e -> Exec.sandbox(e, v)
+      {:approval_policy, v}, e -> Exec.approval_policy(e, v)
+      {:full_auto, true}, e -> Exec.full_auto(e)
+      {:skip_git_repo_check, true}, e -> Exec.skip_git_repo_check(e)
+      {:ephemeral, true}, e -> Exec.ephemeral(e)
+      {:dangerously_bypass_approvals_and_sandbox, true}, e ->
+        Exec.dangerously_bypass_approvals_and_sandbox(e)
+      _other, e -> e
+    end)
+  end
+
+  defp build_exec_resume(session, prompt, per_call_opts) do
+    merged_opts = Keyword.merge(session.exec_opts, per_call_opts)
+
+    resume =
+      ExecResume.new()
+      |> ExecResume.session_id(session.session_id)
+      |> ExecResume.prompt(prompt)
+
+    Enum.reduce(merged_opts, resume, fn
+      {:model, v}, e -> ExecResume.model(e, v)
+      {:full_auto, true}, e -> ExecResume.full_auto(e)
+      {:skip_git_repo_check, true}, e -> ExecResume.skip_git_repo_check(e)
+      {:ephemeral, true}, e -> ExecResume.ephemeral(e)
+      {:dangerously_bypass_approvals_and_sandbox, true}, e ->
+        ExecResume.dangerously_bypass_approvals_and_sandbox(e)
+      _other, e -> e
+    end)
+  end
+
+  defp build_stream(%__MODULE__{session_id: nil} = session, prompt, per_call_opts) do
+    exec = build_exec(session, prompt, per_call_opts)
+    Exec.stream(exec, session.config)
+  end
+
+  defp build_stream(%__MODULE__{session_id: sid} = session, prompt, per_call_opts)
+       when is_binary(sid) do
+    exec_resume = build_exec_resume(session, prompt, per_call_opts)
+    ExecResume.stream(exec_resume, session.config)
+  end
+
+  defp extract_session_id(events) do
+    Enum.find_value(events, fn event ->
+      JsonLineEvent.get(event, "session_id")
+    end)
+  end
+
+  defp maybe_capture_session_id(event, ref, parent) do
+    case JsonLineEvent.get(event, "session_id") do
+      nil -> :ok
+      sid -> Kernel.send(parent, {ref, :session_id, sid})
+    end
+  end
+
+  defp events_to_result(events) do
+    stdout =
+      events
+      |> Enum.map(fn event -> event.raw end)
+      |> Enum.join("\n")
+
+    %Result{
+      stdout: stdout,
+      stderr: "",
+      exit_code: 0,
+      success: true
+    }
+  end
+end

--- a/lib/codex_wrapper/session_server.ex
+++ b/lib/codex_wrapper/session_server.ex
@@ -1,0 +1,179 @@
+defmodule CodexWrapper.SessionServer do
+  @moduledoc """
+  GenServer wrapper for long-running multi-turn sessions.
+
+  Holds a `CodexWrapper.Session` in state and provides a process-based
+  interface for OTP applications, supervision trees, and concurrent access.
+
+  ## Usage
+
+      config = CodexWrapper.Config.new(working_dir: "/path/to/project")
+
+      {:ok, pid} = CodexWrapper.SessionServer.start_link(
+        config: config,
+        exec_opts: [model: "o3", full_auto: true]
+      )
+
+      {:ok, result} = CodexWrapper.SessionServer.send_message(pid, "What files are here?")
+      {:ok, result} = CodexWrapper.SessionServer.send_message(pid, "Add tests for lib/foo.ex")
+
+      CodexWrapper.SessionServer.total_cost(pid)
+      #=> 0.0
+
+  ## Supervision
+
+      children = [
+        {CodexWrapper.SessionServer,
+         name: :my_agent,
+         config: config,
+         exec_opts: [model: "o3"]}
+      ]
+
+      Supervisor.start_link(children, strategy: :one_for_one)
+
+      # Then use the registered name
+      CodexWrapper.SessionServer.send_message(:my_agent, "hello")
+  """
+
+  use GenServer
+
+  alias CodexWrapper.{Config, Result, Session}
+
+  @type server :: GenServer.server()
+
+  @type option ::
+          {:config, Config.t()}
+          | {:exec_opts, keyword()}
+          | {:session_id, String.t()}
+          | {:name, GenServer.name()}
+          | GenServer.option()
+
+  # --- Client API ---
+
+  @doc """
+  Start a session server.
+
+  ## Options
+
+    * `:config` - (required) `%Config{}` struct
+    * `:exec_opts` - Exec options applied to every turn (e.g. `model`, `sandbox`)
+    * `:session_id` - Resume an existing session by ID
+    * `:name` - Register the process with a name
+
+  Also accepts standard `GenServer.start_link/3` options.
+  """
+  @spec start_link([option()]) :: GenServer.on_start()
+  def start_link(opts) do
+    {config, opts} = Keyword.pop!(opts, :config)
+    {exec_opts, opts} = Keyword.pop(opts, :exec_opts, [])
+    {session_id, opts} = Keyword.pop(opts, :session_id)
+
+    init_arg = %{config: config, exec_opts: exec_opts, session_id: session_id}
+    GenServer.start_link(__MODULE__, init_arg, opts)
+  end
+
+  @doc """
+  Send a message in the session. Blocks until the CLI responds.
+
+  Returns `{:ok, %Result{}}` or `{:error, reason}`.
+  """
+  @spec send_message(server(), String.t(), keyword()) ::
+          {:ok, Result.t()} | {:error, term()}
+  def send_message(server, prompt, opts \\ []) do
+    GenServer.call(server, {:send, prompt, opts}, :infinity)
+  end
+
+  @doc """
+  Get the session ID (if established).
+  """
+  @spec session_id(server()) :: String.t() | nil
+  def session_id(server) do
+    GenServer.call(server, :session_id)
+  end
+
+  @doc """
+  Get the number of completed turns.
+  """
+  @spec turn_count(server()) :: non_neg_integer()
+  def turn_count(server) do
+    GenServer.call(server, :turn_count)
+  end
+
+  @doc """
+  Get the total cost across all turns.
+  """
+  @spec total_cost(server()) :: float()
+  def total_cost(server) do
+    GenServer.call(server, :total_cost)
+  end
+
+  @doc """
+  Get the last result, if any.
+  """
+  @spec last_result(server()) :: Result.t() | nil
+  def last_result(server) do
+    GenServer.call(server, :last_result)
+  end
+
+  @doc """
+  Get the full conversation history.
+  """
+  @spec history(server()) :: [Result.t()]
+  def history(server) do
+    GenServer.call(server, :history)
+  end
+
+  @doc """
+  Get the underlying `%Session{}` struct (snapshot).
+  """
+  @spec get_session(server()) :: Session.t()
+  def get_session(server) do
+    GenServer.call(server, :get_session)
+  end
+
+  # --- Server callbacks ---
+
+  @impl true
+  def init(%{config: config, exec_opts: exec_opts, session_id: nil}) do
+    {:ok, Session.new(config, exec_opts)}
+  end
+
+  def init(%{config: config, exec_opts: exec_opts, session_id: session_id}) do
+    {:ok, Session.resume(config, session_id, exec_opts)}
+  end
+
+  @impl true
+  def handle_call({:send, prompt, opts}, _from, session) do
+    case Session.send(session, prompt, opts) do
+      {:ok, new_session, result} ->
+        {:reply, {:ok, result}, new_session}
+
+      {:error, _reason} = error ->
+        {:reply, error, session}
+    end
+  end
+
+  def handle_call(:session_id, _from, session) do
+    {:reply, Session.session_id(session), session}
+  end
+
+  def handle_call(:turn_count, _from, session) do
+    {:reply, Session.turn_count(session), session}
+  end
+
+  def handle_call(:total_cost, _from, session) do
+    {:reply, Session.total_cost(session), session}
+  end
+
+  def handle_call(:last_result, _from, session) do
+    {:reply, Session.last_result(session), session}
+  end
+
+  def handle_call(:history, _from, session) do
+    {:reply, Session.turns(session), session}
+  end
+
+  def handle_call(:get_session, _from, session) do
+    {:reply, session, session}
+  end
+end

--- a/test/codex_wrapper/exec_resume_test.exs
+++ b/test/codex_wrapper/exec_resume_test.exs
@@ -1,0 +1,219 @@
+defmodule CodexWrapper.ExecResumeTest do
+  use ExUnit.Case, async: true
+
+  alias CodexWrapper.ExecResume
+
+  describe "new/0" do
+    test "defaults" do
+      exec = ExecResume.new()
+      assert exec.session_id == nil
+      assert exec.prompt == nil
+      assert exec.last == false
+      assert exec.all == false
+      assert exec.model == nil
+      assert exec.full_auto == false
+      assert exec.dangerously_bypass_approvals_and_sandbox == false
+      assert exec.skip_git_repo_check == false
+      assert exec.ephemeral == false
+      assert exec.json == false
+      assert exec.output_last_message == nil
+      assert exec.images == []
+      assert exec.config_overrides == []
+      assert exec.enabled_features == []
+      assert exec.disabled_features == []
+    end
+  end
+
+  describe "builder functions" do
+    test "session_id/2" do
+      exec = ExecResume.new() |> ExecResume.session_id("abc-123")
+      assert exec.session_id == "abc-123"
+    end
+
+    test "prompt/2" do
+      exec = ExecResume.new() |> ExecResume.prompt("continue")
+      assert exec.prompt == "continue"
+    end
+
+    test "last/1" do
+      exec = ExecResume.new() |> ExecResume.last()
+      assert exec.last == true
+    end
+
+    test "all/1" do
+      exec = ExecResume.new() |> ExecResume.all()
+      assert exec.all == true
+    end
+
+    test "model/2" do
+      exec = ExecResume.new() |> ExecResume.model("o3")
+      assert exec.model == "o3"
+    end
+
+    test "full_auto/1" do
+      exec = ExecResume.new() |> ExecResume.full_auto()
+      assert exec.full_auto == true
+    end
+
+    test "dangerously_bypass_approvals_and_sandbox/1" do
+      exec = ExecResume.new() |> ExecResume.dangerously_bypass_approvals_and_sandbox()
+      assert exec.dangerously_bypass_approvals_and_sandbox == true
+    end
+
+    test "skip_git_repo_check/1" do
+      exec = ExecResume.new() |> ExecResume.skip_git_repo_check()
+      assert exec.skip_git_repo_check == true
+    end
+
+    test "ephemeral/1" do
+      exec = ExecResume.new() |> ExecResume.ephemeral()
+      assert exec.ephemeral == true
+    end
+
+    test "json/1" do
+      exec = ExecResume.new() |> ExecResume.json()
+      assert exec.json == true
+    end
+
+    test "output_last_message/2" do
+      exec = ExecResume.new() |> ExecResume.output_last_message("/tmp/msg.json")
+      assert exec.output_last_message == "/tmp/msg.json"
+    end
+
+    test "image/2 accumulates" do
+      exec = ExecResume.new() |> ExecResume.image("a.png") |> ExecResume.image("b.png")
+      assert exec.images == ["a.png", "b.png"]
+    end
+
+    test "config/2 accumulates" do
+      exec = ExecResume.new() |> ExecResume.config("key=val") |> ExecResume.config("k2=v2")
+      assert exec.config_overrides == ["key=val", "k2=v2"]
+    end
+
+    test "enable/2 accumulates" do
+      exec = ExecResume.new() |> ExecResume.enable("feat1") |> ExecResume.enable("feat2")
+      assert exec.enabled_features == ["feat1", "feat2"]
+    end
+
+    test "disable/2 accumulates" do
+      exec = ExecResume.new() |> ExecResume.disable("feat1")
+      assert exec.disabled_features == ["feat1"]
+    end
+  end
+
+  describe "args/1" do
+    test "minimal args" do
+      args = ExecResume.new() |> ExecResume.args()
+      assert args == ["exec", "resume"]
+    end
+
+    test "with session_id only" do
+      args = ExecResume.new() |> ExecResume.session_id("abc-123") |> ExecResume.args()
+      assert args == ["exec", "resume", "abc-123"]
+    end
+
+    test "with session_id and prompt" do
+      args =
+        ExecResume.new()
+        |> ExecResume.session_id("abc-123")
+        |> ExecResume.prompt("continue")
+        |> ExecResume.args()
+
+      assert args == ["exec", "resume", "abc-123", "continue"]
+    end
+
+    test "with --last flag" do
+      args = ExecResume.new() |> ExecResume.last() |> ExecResume.args()
+      assert "--last" in args
+    end
+
+    test "full args match Rust ordering" do
+      args =
+        ExecResume.new()
+        |> ExecResume.model("gpt-5")
+        |> ExecResume.full_auto()
+        |> ExecResume.skip_git_repo_check()
+        |> ExecResume.json()
+        |> ExecResume.session_id("abc-123")
+        |> ExecResume.prompt("continue")
+        |> ExecResume.args()
+
+      assert args == [
+               "exec", "resume",
+               "--model", "gpt-5",
+               "--full-auto",
+               "--skip-git-repo-check",
+               "--json",
+               "abc-123",
+               "continue"
+             ]
+    end
+
+    test "config overrides come first" do
+      args =
+        ExecResume.new()
+        |> ExecResume.config("key=val")
+        |> ExecResume.model("o3")
+        |> ExecResume.args()
+
+      config_idx = Enum.find_index(args, &(&1 == "-c"))
+      model_idx = Enum.find_index(args, &(&1 == "--model"))
+      assert config_idx < model_idx
+    end
+
+    test "session_id and prompt are last" do
+      args =
+        ExecResume.new()
+        |> ExecResume.model("o3")
+        |> ExecResume.json()
+        |> ExecResume.session_id("sess-1")
+        |> ExecResume.prompt("the prompt")
+        |> ExecResume.args()
+
+      assert Enum.slice(args, -2, 2) == ["sess-1", "the prompt"]
+    end
+
+    test "boolean flags" do
+      args =
+        ExecResume.new()
+        |> ExecResume.full_auto()
+        |> ExecResume.dangerously_bypass_approvals_and_sandbox()
+        |> ExecResume.last()
+        |> ExecResume.all()
+        |> ExecResume.args()
+
+      assert "--full-auto" in args
+      assert "--dangerously-bypass-approvals-and-sandbox" in args
+      assert "--last" in args
+      assert "--all" in args
+    end
+
+    test "list flags repeat" do
+      args =
+        ExecResume.new()
+        |> ExecResume.image("a.png")
+        |> ExecResume.image("b.png")
+        |> ExecResume.args()
+
+      assert "--image" in args
+      assert "a.png" in args
+      assert "b.png" in args
+    end
+  end
+
+  describe "parse_output/2" do
+    test "returns result for exit code 0" do
+      assert {:ok, result} = ExecResume.parse_output("output text\n", 0)
+      assert result.stdout == "output text\n"
+      assert result.exit_code == 0
+      assert result.success == true
+    end
+
+    test "returns result for non-zero exit code" do
+      assert {:ok, result} = ExecResume.parse_output("error\n", 1)
+      assert result.stdout == "error\n"
+      assert result.exit_code == 1
+      assert result.success == false
+    end
+  end
+end

--- a/test/codex_wrapper/session_server_test.exs
+++ b/test/codex_wrapper/session_server_test.exs
@@ -1,0 +1,61 @@
+defmodule CodexWrapper.SessionServerTest do
+  use ExUnit.Case, async: true
+
+  alias CodexWrapper.{Config, SessionServer}
+
+  describe "start_link/1" do
+    test "initial state" do
+      config = Config.new()
+      {:ok, pid} = SessionServer.start_link(config: config)
+
+      assert SessionServer.session_id(pid) == nil
+      assert SessionServer.turn_count(pid) == 0
+      assert SessionServer.total_cost(pid) == 0.0
+      assert SessionServer.last_result(pid) == nil
+      assert SessionServer.history(pid) == []
+    end
+
+    test "with exec opts" do
+      config = Config.new()
+      {:ok, pid} = SessionServer.start_link(config: config, exec_opts: [model: "o3"])
+
+      session = SessionServer.get_session(pid)
+      assert session.exec_opts == [model: "o3"]
+    end
+
+    test "with session_id for resume" do
+      config = Config.new()
+      {:ok, pid} = SessionServer.start_link(config: config, session_id: "abc-123")
+
+      assert SessionServer.session_id(pid) == "abc-123"
+    end
+
+    test "with name registration" do
+      config = Config.new()
+
+      {:ok, _pid} =
+        SessionServer.start_link(config: config, name: :test_codex_session_server)
+
+      assert SessionServer.turn_count(:test_codex_session_server) == 0
+    end
+
+    test "child_spec for supervision" do
+      config = Config.new()
+      spec = SessionServer.child_spec(config: config, name: :supervised_codex_test)
+
+      assert spec.id == SessionServer
+      assert spec.start == {SessionServer, :start_link, [[config: config, name: :supervised_codex_test]]}
+    end
+  end
+
+  describe "get_session/1" do
+    test "returns session struct" do
+      config = Config.new()
+      {:ok, pid} = SessionServer.start_link(config: config)
+
+      session = SessionServer.get_session(pid)
+      assert %CodexWrapper.Session{} = session
+      assert session.config == config
+    end
+  end
+end

--- a/test/codex_wrapper/session_test.exs
+++ b/test/codex_wrapper/session_test.exs
@@ -1,0 +1,91 @@
+defmodule CodexWrapper.SessionTest do
+  use ExUnit.Case, async: true
+
+  alias CodexWrapper.{Config, Session}
+
+  describe "new/2" do
+    test "creates session with config" do
+      config = Config.new()
+      session = Session.new(config)
+      assert session.config == config
+      assert session.session_id == nil
+      assert session.history == []
+      assert session.exec_opts == []
+    end
+
+    test "with exec opts" do
+      config = Config.new()
+      session = Session.new(config, model: "o3", full_auto: true)
+      assert session.exec_opts == [model: "o3", full_auto: true]
+    end
+  end
+
+  describe "resume/3" do
+    test "sets session_id" do
+      config = Config.new()
+      session = Session.resume(config, "abc-123")
+      assert Session.session_id(session) == "abc-123"
+    end
+
+    test "with exec opts" do
+      config = Config.new()
+      session = Session.resume(config, "abc-123", model: "o3")
+      assert session.exec_opts == [model: "o3"]
+      assert Session.session_id(session) == "abc-123"
+    end
+  end
+
+  describe "session_id/1" do
+    test "returns nil when no session_id" do
+      config = Config.new()
+      session = Session.new(config)
+      assert Session.session_id(session) == nil
+    end
+
+    test "returns session_id when set" do
+      config = Config.new()
+      session = Session.resume(config, "abc-123")
+      assert Session.session_id(session) == "abc-123"
+    end
+  end
+
+  describe "turn_count/1" do
+    test "starts at zero" do
+      config = Config.new()
+      session = Session.new(config)
+      assert Session.turn_count(session) == 0
+    end
+  end
+
+  describe "total_cost/1" do
+    test "returns zero" do
+      config = Config.new()
+      session = Session.new(config)
+      assert Session.total_cost(session) == 0.0
+    end
+  end
+
+  describe "last_result/1" do
+    test "returns nil when no turns" do
+      config = Config.new()
+      session = Session.new(config)
+      assert Session.last_result(session) == nil
+    end
+  end
+
+  describe "turns/1" do
+    test "returns empty list initially" do
+      config = Config.new()
+      session = Session.new(config)
+      assert Session.turns(session) == []
+    end
+  end
+
+  describe "history/1" do
+    test "aliases turns" do
+      config = Config.new()
+      session = Session.new(config)
+      assert Session.history(session) == Session.turns(session)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Done. Here's what was implemented:

**New modules:**

- **`CodexWrapper.ExecResume`** — Command builder for `codex exec resume [session_id] [prompt]`. Supports `--last`, `--all`, `--model`, `--json`, and all standard flags. Arg ordering matches the Rust wrapper.

- **`CodexWrapper.Session`** — In-process session state. First turn uses `Exec` with `--json` to create a session; subsequent turns use `ExecResume` with the extracted `session_id`. API: `new/2`, `resume/3`, `send/3`, `stream/3`, `sessi

## Test results

All checks pass:

- **mix test**: 131 tests, 0 failures
- **mix compile --warnings-as-errors**: clean, no warnings

No fixes needed.

---
Generated by arsenale | Cost: $2.11 | Closes #5