### PR TITLE
feat: Completions command (codex completion)

### DIFF
--- a/lib/codex_wrapper.ex
+++ b/lib/codex_wrapper.ex
@@ -25,7 +25,7 @@ defmodule CodexWrapper do
   3. System PATH lookup
   """
 
-  alias CodexWrapper.Commands.Version
+  alias CodexWrapper.Commands.{Completion, Version}
   alias CodexWrapper.{Config, Exec, JsonLineEvent, Result, Review}
 
   @doc """
@@ -39,6 +39,19 @@ defmodule CodexWrapper do
   def version(opts \\ []) do
     config = Config.new(opts)
     Version.execute(config)
+  end
+
+  @doc """
+  Generate a shell completion script.
+
+  ## Examples
+
+      {:ok, script} = CodexWrapper.completion(:zsh)
+  """
+  @spec completion(Completion.shell(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def completion(shell \\ :bash, opts \\ []) do
+    config = Config.new(opts)
+    Completion.generate(config, shell)
   end
 
   @doc """

--- a/lib/codex_wrapper/commands/completion.ex
+++ b/lib/codex_wrapper/commands/completion.ex
@@ -1,0 +1,32 @@
+defmodule CodexWrapper.Commands.Completion do
+  @moduledoc """
+  Shell completion script generation.
+
+  Wraps `codex completion [SHELL]` to generate shell-specific completion scripts.
+  """
+
+  alias CodexWrapper.Config
+
+  @type shell :: :bash | :zsh | :fish | :elvish | :powershell
+
+  @shells [:bash, :zsh, :fish, :elvish, :powershell]
+
+  @doc """
+  Generate a shell completion script.
+
+  ## Examples
+
+      config = CodexWrapper.Config.new()
+      {:ok, script} = CodexWrapper.Commands.Completion.generate(config)
+      {:ok, script} = CodexWrapper.Commands.Completion.generate(config, :zsh)
+  """
+  @spec generate(Config.t(), shell()) :: {:ok, String.t()} | {:error, term()}
+  def generate(%Config{} = config, shell \\ :bash) when shell in @shells do
+    args = Config.base_args(config) ++ ["completion", Atom.to_string(shell)]
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+end

--- a/test/codex_wrapper/commands/completion_test.exs
+++ b/test/codex_wrapper/commands/completion_test.exs
@@ -1,0 +1,29 @@
+defmodule CodexWrapper.Commands.CompletionTest do
+  use ExUnit.Case, async: true
+
+  alias CodexWrapper.Commands.Completion
+  alias CodexWrapper.Config
+
+  describe "generate/2" do
+    test "defaults to bash shell" do
+      config = Config.new(binary: "echo")
+      assert {:ok, output} = Completion.generate(config)
+      assert output =~ "completion bash"
+    end
+
+    test "accepts zsh shell" do
+      config = Config.new(binary: "echo")
+      assert {:ok, output} = Completion.generate(config)
+      assert output =~ "completion"
+    end
+
+    test "accepts all valid shells" do
+      config = Config.new(binary: "echo")
+
+      for shell <- [:bash, :zsh, :fish, :elvish, :powershell] do
+        assert {:ok, output} = Completion.generate(config, shell)
+        assert output =~ "completion #{shell}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Done. Here's what was implemented:

- **`CodexWrapper.Commands.Completion`** - wraps `codex completion [SHELL]` with `generate/2`, supporting `:bash`, `:zsh`, `:fish`, `:elvish`, and `:powershell`
- **`CodexWrapper.completion/2`** - convenience function in the main module
- **Tests** - covering default shell, all valid shells

## Test results

All checks pass:
- **mix test**: 167 tests, 0 failures
- **mix compile --warnings-as-errors**: clean compilation, no warnings

No fixes needed.

---
Generated by arsenale | Cost: $1.0 | Closes #18