### PR TITLE
feat: Sandbox, Fork, and Apply commands

### DIFF
--- a/lib/codex_wrapper/commands/apply.ex
+++ b/lib/codex_wrapper/commands/apply.ex
@@ -1,0 +1,36 @@
+defmodule CodexWrapper.Commands.Apply do
+  @moduledoc """
+  Apply command — apply an agent diff as git apply.
+
+  Wraps `codex apply <task-id>`.
+
+  ## Usage
+
+      config = CodexWrapper.Config.new(working_dir: "/path/to/repo")
+
+      {:ok, output} = CodexWrapper.Commands.Apply.execute(config, "abc-123")
+  """
+
+  alias CodexWrapper.Config
+
+  @doc """
+  Apply the diff from the given task ID.
+  """
+  @spec execute(Config.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def execute(%Config{} = config, task_id) when is_binary(task_id) do
+    args = Config.base_args(config) ++ ["apply", task_id]
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc """
+  Build the argument list for the apply command.
+  """
+  @spec build_args(String.t()) :: [String.t()]
+  def build_args(task_id) when is_binary(task_id) do
+    ["apply", task_id]
+  end
+end

--- a/lib/codex_wrapper/commands/fork.ex
+++ b/lib/codex_wrapper/commands/fork.ex
@@ -1,0 +1,218 @@
+defmodule CodexWrapper.Commands.Fork do
+  @moduledoc """
+  Fork command — fork an existing session to try a different approach.
+
+  Wraps `codex fork [session-id] [prompt]` with the full set of CLI flags.
+
+  ## Usage
+
+      config = CodexWrapper.Config.new(working_dir: "/path/to/project")
+
+      # Fork the most recent session
+      fork = CodexWrapper.Commands.Fork.new()
+        |> CodexWrapper.Commands.Fork.last()
+        |> CodexWrapper.Commands.Fork.prompt("take a different approach")
+
+      {:ok, result} = CodexWrapper.Commands.Fork.execute(fork, config)
+
+      # Fork a specific session by ID
+      fork = CodexWrapper.Commands.Fork.new()
+        |> CodexWrapper.Commands.Fork.session_id("abc-123")
+        |> CodexWrapper.Commands.Fork.model("o3")
+
+      {:ok, result} = CodexWrapper.Commands.Fork.execute(fork, config)
+  """
+
+  @behaviour CodexWrapper.Command
+
+  alias CodexWrapper.{Command, Config, Result}
+
+  @type sandbox_mode :: :read_only | :workspace_write | :danger_full_access
+  @type approval_policy :: :untrusted | :on_failure | :on_request | :never
+
+  @type t :: %__MODULE__{
+          session_id: String.t() | nil,
+          prompt: String.t() | nil,
+          last: boolean(),
+          all: boolean(),
+          model: String.t() | nil,
+          sandbox: sandbox_mode() | nil,
+          approval_policy: approval_policy() | nil,
+          full_auto: boolean(),
+          dangerously_bypass_approvals_and_sandbox: boolean(),
+          cd: String.t() | nil,
+          search: boolean(),
+          add_dirs: [String.t()],
+          images: [String.t()],
+          config_overrides: [String.t()],
+          enabled_features: [String.t()],
+          disabled_features: [String.t()]
+        }
+
+  defstruct [
+    :session_id,
+    :prompt,
+    :model,
+    :sandbox,
+    :approval_policy,
+    :cd,
+    last: false,
+    all: false,
+    full_auto: false,
+    dangerously_bypass_approvals_and_sandbox: false,
+    search: false,
+    add_dirs: [],
+    images: [],
+    config_overrides: [],
+    enabled_features: [],
+    disabled_features: []
+  ]
+
+  # --- Constructor ---
+
+  @doc """
+  Create a new fork command.
+  """
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  # --- Builder functions ---
+
+  @doc "Set the session ID to fork."
+  @spec session_id(t(), String.t()) :: t()
+  def session_id(%__MODULE__{} = f, id), do: %{f | session_id: id}
+
+  @doc "Set the prompt for the forked session."
+  @spec prompt(t(), String.t()) :: t()
+  def prompt(%__MODULE__{} = f, prompt), do: %{f | prompt: prompt}
+
+  @doc "Fork the most recent session."
+  @spec last(t()) :: t()
+  def last(%__MODULE__{} = f), do: %{f | last: true}
+
+  @doc "Show all sessions (disables cwd filtering)."
+  @spec all(t()) :: t()
+  def all(%__MODULE__{} = f), do: %{f | all: true}
+
+  @doc "Set the model."
+  @spec model(t(), String.t()) :: t()
+  def model(%__MODULE__{} = f, model), do: %{f | model: model}
+
+  @doc "Set the sandbox mode."
+  @spec sandbox(t(), sandbox_mode()) :: t()
+  def sandbox(%__MODULE__{} = f, mode), do: %{f | sandbox: mode}
+
+  @doc "Set the approval policy."
+  @spec approval_policy(t(), approval_policy()) :: t()
+  def approval_policy(%__MODULE__{} = f, policy), do: %{f | approval_policy: policy}
+
+  @doc "Enable full-auto mode."
+  @spec full_auto(t()) :: t()
+  def full_auto(%__MODULE__{} = f), do: %{f | full_auto: true}
+
+  @doc "Bypass all approvals and sandbox. Use with extreme caution."
+  @spec dangerously_bypass_approvals_and_sandbox(t()) :: t()
+  def dangerously_bypass_approvals_and_sandbox(%__MODULE__{} = f),
+    do: %{f | dangerously_bypass_approvals_and_sandbox: true}
+
+  @doc "Set the working directory for the codex subprocess."
+  @spec cd(t(), String.t()) :: t()
+  def cd(%__MODULE__{} = f, dir), do: %{f | cd: dir}
+
+  @doc "Enable live web search."
+  @spec search(t()) :: t()
+  def search(%__MODULE__{} = f), do: %{f | search: true}
+
+  @doc "Add a directory for context."
+  @spec add_dir(t(), String.t()) :: t()
+  def add_dir(%__MODULE__{} = f, dir), do: %{f | add_dirs: f.add_dirs ++ [dir]}
+
+  @doc "Add an image path."
+  @spec image(t(), String.t()) :: t()
+  def image(%__MODULE__{} = f, path), do: %{f | images: f.images ++ [path]}
+
+  @doc "Add a config override (key=value)."
+  @spec config(t(), String.t()) :: t()
+  def config(%__MODULE__{} = f, kv), do: %{f | config_overrides: f.config_overrides ++ [kv]}
+
+  @doc "Enable a feature."
+  @spec enable(t(), String.t()) :: t()
+  def enable(%__MODULE__{} = f, feature),
+    do: %{f | enabled_features: f.enabled_features ++ [feature]}
+
+  @doc "Disable a feature."
+  @spec disable(t(), String.t()) :: t()
+  def disable(%__MODULE__{} = f, feature),
+    do: %{f | disabled_features: f.disabled_features ++ [feature]}
+
+  # --- Execution ---
+
+  @doc """
+  Execute the fork command synchronously, returning a parsed `%Result{}`.
+  """
+  @spec execute(t(), Config.t()) :: {:ok, Result.t()} | {:error, term()}
+  def execute(%__MODULE__{} = fork, %Config{} = config) do
+    Command.run(__MODULE__, fork, config)
+  end
+
+  # --- Command behaviour ---
+
+  @impl Command
+  def args(%__MODULE__{} = f) do
+    ["fork"]
+    |> add_list("-c", f.config_overrides)
+    |> add_list("--enable", f.enabled_features)
+    |> add_list("--disable", f.disabled_features)
+    |> add_bool("--last", f.last)
+    |> add_bool("--all", f.all)
+    |> add_list("--image", f.images)
+    |> add_opt("--model", f.model)
+    |> add_opt("--sandbox", format_sandbox(f.sandbox))
+    |> add_opt("--ask-for-approval", format_approval_policy(f.approval_policy))
+    |> add_bool("--full-auto", f.full_auto)
+    |> add_bool(
+      "--dangerously-bypass-approvals-and-sandbox",
+      f.dangerously_bypass_approvals_and_sandbox
+    )
+    |> add_opt("--cd", f.cd)
+    |> add_bool("--search", f.search)
+    |> add_list("--add-dir", f.add_dirs)
+    |> add_opt_flag(f.session_id)
+    |> add_opt_flag(f.prompt)
+  end
+
+  @impl Command
+  def parse_output(stdout, exit_code) do
+    result = Result.from_cmd({stdout, exit_code})
+
+    if result.success do
+      {:ok, result}
+    else
+      {:ok, result}
+    end
+  end
+
+  # --- Arg helpers ---
+
+  defp add_opt_flag(args, nil), do: args
+  defp add_opt_flag(args, value), do: args ++ [value]
+  defp add_opt(args, _flag, nil), do: args
+  defp add_opt(args, flag, value), do: args ++ [flag, value]
+  defp add_bool(args, _flag, false), do: args
+  defp add_bool(args, flag, true), do: args ++ [flag]
+  defp add_list(args, _flag, []), do: args
+  defp add_list(args, flag, values), do: args ++ Enum.flat_map(values, &[flag, &1])
+
+  # --- Format helpers ---
+
+  defp format_sandbox(nil), do: nil
+  defp format_sandbox(:read_only), do: "read-only"
+  defp format_sandbox(:workspace_write), do: "workspace-write"
+  defp format_sandbox(:danger_full_access), do: "danger-full-access"
+
+  defp format_approval_policy(nil), do: nil
+  defp format_approval_policy(:untrusted), do: "untrusted"
+  defp format_approval_policy(:on_failure), do: "on-failure"
+  defp format_approval_policy(:on_request), do: "on-request"
+  defp format_approval_policy(:never), do: "never"
+end

--- a/lib/codex_wrapper/commands/sandbox.ex
+++ b/lib/codex_wrapper/commands/sandbox.ex
@@ -1,0 +1,79 @@
+defmodule CodexWrapper.Commands.Sandbox do
+  @moduledoc """
+  Sandbox command — run a command inside the Codex sandbox.
+
+  Wraps `codex sandbox <platform> -- <command> [args...]`.
+
+  ## Usage
+
+      config = CodexWrapper.Config.new()
+
+      # Run ls inside a macOS sandbox
+      sandbox = CodexWrapper.Commands.Sandbox.new(:macos, "ls")
+        |> CodexWrapper.Commands.Sandbox.arg("-la")
+
+      {:ok, output} = CodexWrapper.Commands.Sandbox.execute(sandbox, config)
+  """
+
+  alias CodexWrapper.Config
+
+  @type platform :: :macos | :linux | :windows
+
+  @type t :: %__MODULE__{
+          platform: platform(),
+          command: String.t(),
+          command_args: [String.t()]
+        }
+
+  defstruct [:platform, :command, command_args: []]
+
+  # --- Constructor ---
+
+  @doc """
+  Create a sandbox command for the given platform and command.
+  """
+  @spec new(platform(), String.t()) :: t()
+  def new(platform, command) when platform in [:macos, :linux, :windows] and is_binary(command) do
+    %__MODULE__{platform: platform, command: command}
+  end
+
+  # --- Builder functions ---
+
+  @doc "Add an argument to the sandboxed command."
+  @spec arg(t(), String.t()) :: t()
+  def arg(%__MODULE__{} = s, arg), do: %{s | command_args: s.command_args ++ [arg]}
+
+  @doc "Add multiple arguments to the sandboxed command."
+  @spec args(t(), [String.t()]) :: t()
+  def args(%__MODULE__{} = s, args) when is_list(args),
+    do: %{s | command_args: s.command_args ++ args}
+
+  # --- Execution ---
+
+  @doc """
+  Execute the sandbox command synchronously.
+  """
+  @spec execute(t(), Config.t()) :: {:ok, String.t()} | {:error, term()}
+  def execute(%__MODULE__{} = sandbox, %Config{} = config) do
+    all_args = Config.base_args(config) ++ build_args(sandbox)
+
+    case System.cmd(config.binary, all_args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  # --- Arg building ---
+
+  @doc """
+  Build the argument list for this command.
+  """
+  @spec build_args(t()) :: [String.t()]
+  def build_args(%__MODULE__{} = s) do
+    ["sandbox", format_platform(s.platform), "--", s.command] ++ s.command_args
+  end
+
+  defp format_platform(:macos), do: "macos"
+  defp format_platform(:linux), do: "linux"
+  defp format_platform(:windows), do: "windows"
+end

--- a/test/codex_wrapper/commands/apply_test.exs
+++ b/test/codex_wrapper/commands/apply_test.exs
@@ -1,0 +1,15 @@
+defmodule CodexWrapper.Commands.ApplyTest do
+  use ExUnit.Case, async: true
+
+  alias CodexWrapper.Commands.Apply
+
+  describe "build_args/1" do
+    test "produces correct args" do
+      assert Apply.build_args("abc-123") == ["apply", "abc-123"]
+    end
+
+    test "with different task id" do
+      assert Apply.build_args("task-456-def") == ["apply", "task-456-def"]
+    end
+  end
+end

--- a/test/codex_wrapper/commands/fork_test.exs
+++ b/test/codex_wrapper/commands/fork_test.exs
@@ -1,0 +1,300 @@
+defmodule CodexWrapper.Commands.ForkTest do
+  use ExUnit.Case, async: true
+
+  alias CodexWrapper.Commands.Fork
+
+  describe "new/0" do
+    test "defaults" do
+      fork = Fork.new()
+      assert fork.session_id == nil
+      assert fork.prompt == nil
+      assert fork.last == false
+      assert fork.all == false
+      assert fork.model == nil
+      assert fork.sandbox == nil
+      assert fork.approval_policy == nil
+      assert fork.full_auto == false
+      assert fork.dangerously_bypass_approvals_and_sandbox == false
+      assert fork.cd == nil
+      assert fork.search == false
+      assert fork.add_dirs == []
+      assert fork.images == []
+      assert fork.config_overrides == []
+      assert fork.enabled_features == []
+      assert fork.disabled_features == []
+    end
+  end
+
+  describe "builder functions" do
+    test "session_id/2" do
+      fork = Fork.new() |> Fork.session_id("abc-123")
+      assert fork.session_id == "abc-123"
+    end
+
+    test "prompt/2" do
+      fork = Fork.new() |> Fork.prompt("try again")
+      assert fork.prompt == "try again"
+    end
+
+    test "last/1" do
+      fork = Fork.new() |> Fork.last()
+      assert fork.last == true
+    end
+
+    test "all/1" do
+      fork = Fork.new() |> Fork.all()
+      assert fork.all == true
+    end
+
+    test "model/2" do
+      fork = Fork.new() |> Fork.model("o3")
+      assert fork.model == "o3"
+    end
+
+    test "sandbox/2" do
+      fork = Fork.new() |> Fork.sandbox(:read_only)
+      assert fork.sandbox == :read_only
+    end
+
+    test "approval_policy/2" do
+      fork = Fork.new() |> Fork.approval_policy(:on_failure)
+      assert fork.approval_policy == :on_failure
+    end
+
+    test "full_auto/1" do
+      fork = Fork.new() |> Fork.full_auto()
+      assert fork.full_auto == true
+    end
+
+    test "dangerously_bypass_approvals_and_sandbox/1" do
+      fork = Fork.new() |> Fork.dangerously_bypass_approvals_and_sandbox()
+      assert fork.dangerously_bypass_approvals_and_sandbox == true
+    end
+
+    test "cd/2" do
+      fork = Fork.new() |> Fork.cd("/tmp/project")
+      assert fork.cd == "/tmp/project"
+    end
+
+    test "search/1" do
+      fork = Fork.new() |> Fork.search()
+      assert fork.search == true
+    end
+
+    test "add_dir/2 accumulates" do
+      fork = Fork.new() |> Fork.add_dir("/src") |> Fork.add_dir("/lib")
+      assert fork.add_dirs == ["/src", "/lib"]
+    end
+
+    test "image/2 accumulates" do
+      fork = Fork.new() |> Fork.image("a.png") |> Fork.image("b.png")
+      assert fork.images == ["a.png", "b.png"]
+    end
+
+    test "config/2 accumulates" do
+      fork = Fork.new() |> Fork.config("key=val") |> Fork.config("k2=v2")
+      assert fork.config_overrides == ["key=val", "k2=v2"]
+    end
+
+    test "enable/2 accumulates" do
+      fork = Fork.new() |> Fork.enable("feat1") |> Fork.enable("feat2")
+      assert fork.enabled_features == ["feat1", "feat2"]
+    end
+
+    test "disable/2 accumulates" do
+      fork = Fork.new() |> Fork.disable("feat1")
+      assert fork.disabled_features == ["feat1"]
+    end
+  end
+
+  describe "args/1" do
+    test "minimal args" do
+      args = Fork.new() |> Fork.args()
+      assert args == ["fork"]
+    end
+
+    test "with session_id only" do
+      args = Fork.new() |> Fork.session_id("abc-123") |> Fork.args()
+      assert args == ["fork", "abc-123"]
+    end
+
+    test "with session_id and prompt" do
+      args =
+        Fork.new()
+        |> Fork.session_id("abc-123")
+        |> Fork.prompt("try again")
+        |> Fork.args()
+
+      assert args == ["fork", "abc-123", "try again"]
+    end
+
+    test "with --last flag" do
+      args = Fork.new() |> Fork.last() |> Fork.args()
+      assert "--last" in args
+    end
+
+    test "fork last with model and prompt matches Rust ordering" do
+      args =
+        Fork.new()
+        |> Fork.last()
+        |> Fork.model("gpt-5")
+        |> Fork.prompt("take a different approach")
+        |> Fork.args()
+
+      assert args == [
+               "fork",
+               "--last",
+               "--model",
+               "gpt-5",
+               "take a different approach"
+             ]
+    end
+
+    test "fork session_id with full_auto and search matches Rust ordering" do
+      args =
+        Fork.new()
+        |> Fork.session_id("abc-123")
+        |> Fork.full_auto()
+        |> Fork.search()
+        |> Fork.args()
+
+      assert args == ["fork", "--full-auto", "--search", "abc-123"]
+    end
+
+    test "config overrides come first" do
+      args =
+        Fork.new()
+        |> Fork.config("key=val")
+        |> Fork.model("o3")
+        |> Fork.args()
+
+      config_idx = Enum.find_index(args, &(&1 == "-c"))
+      model_idx = Enum.find_index(args, &(&1 == "--model"))
+      assert config_idx < model_idx
+    end
+
+    test "session_id and prompt are last" do
+      args =
+        Fork.new()
+        |> Fork.model("o3")
+        |> Fork.search()
+        |> Fork.session_id("sess-1")
+        |> Fork.prompt("the prompt")
+        |> Fork.args()
+
+      assert Enum.slice(args, -2, 2) == ["sess-1", "the prompt"]
+    end
+
+    test "boolean flags" do
+      args =
+        Fork.new()
+        |> Fork.full_auto()
+        |> Fork.dangerously_bypass_approvals_and_sandbox()
+        |> Fork.last()
+        |> Fork.all()
+        |> Fork.search()
+        |> Fork.args()
+
+      assert "--full-auto" in args
+      assert "--dangerously-bypass-approvals-and-sandbox" in args
+      assert "--last" in args
+      assert "--all" in args
+      assert "--search" in args
+    end
+
+    test "sandbox mode formatting" do
+      args = Fork.new() |> Fork.sandbox(:workspace_write) |> Fork.args()
+      assert args == ["fork", "--sandbox", "workspace-write"]
+    end
+
+    test "approval policy formatting" do
+      args = Fork.new() |> Fork.approval_policy(:on_failure) |> Fork.args()
+      assert args == ["fork", "--ask-for-approval", "on-failure"]
+    end
+
+    test "list flags repeat" do
+      args =
+        Fork.new()
+        |> Fork.image("a.png")
+        |> Fork.image("b.png")
+        |> Fork.args()
+
+      assert "--image" in args
+      assert "a.png" in args
+      assert "b.png" in args
+    end
+
+    test "add_dir flags repeat" do
+      args =
+        Fork.new()
+        |> Fork.add_dir("/src")
+        |> Fork.add_dir("/lib")
+        |> Fork.args()
+
+      assert args == ["fork", "--add-dir", "/src", "--add-dir", "/lib"]
+    end
+
+    test "full args" do
+      args =
+        Fork.new()
+        |> Fork.config("key=val")
+        |> Fork.enable("feat1")
+        |> Fork.disable("feat2")
+        |> Fork.last()
+        |> Fork.image("img.png")
+        |> Fork.model("o3")
+        |> Fork.sandbox(:read_only)
+        |> Fork.approval_policy(:never)
+        |> Fork.full_auto()
+        |> Fork.cd("/tmp")
+        |> Fork.search()
+        |> Fork.add_dir("/extra")
+        |> Fork.session_id("sess-1")
+        |> Fork.prompt("do it")
+        |> Fork.args()
+
+      assert args == [
+               "fork",
+               "-c",
+               "key=val",
+               "--enable",
+               "feat1",
+               "--disable",
+               "feat2",
+               "--last",
+               "--image",
+               "img.png",
+               "--model",
+               "o3",
+               "--sandbox",
+               "read-only",
+               "--ask-for-approval",
+               "never",
+               "--full-auto",
+               "--cd",
+               "/tmp",
+               "--search",
+               "--add-dir",
+               "/extra",
+               "sess-1",
+               "do it"
+             ]
+    end
+  end
+
+  describe "parse_output/2" do
+    test "returns result for exit code 0" do
+      assert {:ok, result} = Fork.parse_output("output text\n", 0)
+      assert result.stdout == "output text\n"
+      assert result.exit_code == 0
+      assert result.success == true
+    end
+
+    test "returns result for non-zero exit code" do
+      assert {:ok, result} = Fork.parse_output("error\n", 1)
+      assert result.stdout == "error\n"
+      assert result.exit_code == 1
+      assert result.success == false
+    end
+  end
+end

--- a/test/codex_wrapper/commands/sandbox_test.exs
+++ b/test/codex_wrapper/commands/sandbox_test.exs
@@ -1,0 +1,72 @@
+defmodule CodexWrapper.Commands.SandboxTest do
+  use ExUnit.Case, async: true
+
+  alias CodexWrapper.Commands.Sandbox
+
+  describe "new/2" do
+    test "creates sandbox with platform and command" do
+      sandbox = Sandbox.new(:macos, "ls")
+      assert sandbox.platform == :macos
+      assert sandbox.command == "ls"
+      assert sandbox.command_args == []
+    end
+
+    test "accepts all platforms" do
+      assert Sandbox.new(:macos, "cmd").platform == :macos
+      assert Sandbox.new(:linux, "cmd").platform == :linux
+      assert Sandbox.new(:windows, "cmd").platform == :windows
+    end
+  end
+
+  describe "builder functions" do
+    test "arg/2 accumulates" do
+      sandbox = Sandbox.new(:macos, "ls") |> Sandbox.arg("-la") |> Sandbox.arg("/tmp")
+      assert sandbox.command_args == ["-la", "/tmp"]
+    end
+
+    test "args/2 adds multiple arguments" do
+      sandbox = Sandbox.new(:linux, "cat") |> Sandbox.args(["/etc/hosts", "/etc/passwd"])
+      assert sandbox.command_args == ["/etc/hosts", "/etc/passwd"]
+    end
+
+    test "arg/2 and args/2 combine" do
+      sandbox =
+        Sandbox.new(:macos, "ls")
+        |> Sandbox.arg("-la")
+        |> Sandbox.args(["/tmp", "/var"])
+
+      assert sandbox.command_args == ["-la", "/tmp", "/var"]
+    end
+  end
+
+  describe "build_args/1" do
+    test "macos sandbox" do
+      args = Sandbox.new(:macos, "ls") |> Sandbox.arg("-la") |> Sandbox.build_args()
+      assert args == ["sandbox", "macos", "--", "ls", "-la"]
+    end
+
+    test "linux sandbox" do
+      args = Sandbox.new(:linux, "cat") |> Sandbox.arg("/etc/hosts") |> Sandbox.build_args()
+      assert args == ["sandbox", "linux", "--", "cat", "/etc/hosts"]
+    end
+
+    test "windows sandbox" do
+      args = Sandbox.new(:windows, "dir") |> Sandbox.build_args()
+      assert args == ["sandbox", "windows", "--", "dir"]
+    end
+
+    test "no command args" do
+      args = Sandbox.new(:macos, "whoami") |> Sandbox.build_args()
+      assert args == ["sandbox", "macos", "--", "whoami"]
+    end
+
+    test "multiple command args" do
+      args =
+        Sandbox.new(:linux, "grep")
+        |> Sandbox.args(["-r", "pattern", "/src"])
+        |> Sandbox.build_args()
+
+      assert args == ["sandbox", "linux", "--", "grep", "-r", "pattern", "/src"]
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Done. Here's what was implemented:

- **`CodexWrapper.Commands.Sandbox`** - Builder with `new(platform, command)`, `arg/2`, `args/2`. Platforms: `:macos`, `:linux`, `:windows`. Generates `sandbox <platform> -- <command> [args...]`.

- **`CodexWrapper.Commands.Fork`** - Full builder mirroring `ExecResume` pattern with session_id, prompt, last, all, model, sandbox, approval_policy, full_auto, cd, search, add_dir, images, config overrides, and feature flags. Implements `Command` behaviour.

- **`Co

## Test results

All checks pass:

- **`mix test`**: 209 tests, 0 failures
- **`mix compile --warnings-as-errors`**: Clean compilation, no warnings

No fixes needed.

---
Generated by arsenale | Cost: $1.23 | Closes #13