### PR TITLE
feat: MCP server command (codex mcp-server)

### DIFF
--- a/lib/codex_wrapper/commands/mcp_server.ex
+++ b/lib/codex_wrapper/commands/mcp_server.ex
@@ -1,0 +1,62 @@
+defmodule CodexWrapper.Commands.McpServer do
+  @moduledoc """
+  Start Codex as an MCP server over stdio.
+
+  Wraps `codex mcp-server`.
+
+  ## Options
+
+    * `:config` - list of `"key=value"` config overrides (`-c`)
+    * `:enable` - list of feature flags to enable (`--enable`)
+    * `:disable` - list of feature flags to disable (`--disable`)
+  """
+
+  alias CodexWrapper.Config
+
+  @doc """
+  Start Codex as an MCP server.
+
+  ## Options
+
+    * `:config` - list of `"key=value"` config overrides
+    * `:enable` - list of feature flags to enable
+    * `:disable` - list of feature flags to disable
+
+  ## Examples
+
+      config = CodexWrapper.Config.new()
+      CodexWrapper.Commands.McpServer.start(config)
+      CodexWrapper.Commands.McpServer.start(config, config: ["model=\\"gpt-5\\""], enable: ["web-search"])
+  """
+  @spec start(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def start(%Config{} = config, opts \\ []) do
+    args = Config.base_args(config) ++ ["mcp-server"] ++ build_args(opts)
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  defp build_args(opts) do
+    config_args(opts[:config]) ++ enable_args(opts[:enable]) ++ disable_args(opts[:disable])
+  end
+
+  defp config_args(nil), do: []
+
+  defp config_args(overrides) do
+    Enum.flat_map(overrides, fn v -> ["-c", v] end)
+  end
+
+  defp enable_args(nil), do: []
+
+  defp enable_args(features) do
+    Enum.flat_map(features, fn v -> ["--enable", v] end)
+  end
+
+  defp disable_args(nil), do: []
+
+  defp disable_args(features) do
+    Enum.flat_map(features, fn v -> ["--disable", v] end)
+  end
+end

--- a/test/codex_wrapper/commands/mcp_server_test.exs
+++ b/test/codex_wrapper/commands/mcp_server_test.exs
@@ -1,0 +1,59 @@
+defmodule CodexWrapper.Commands.McpServerTest do
+  use ExUnit.Case, async: true
+
+  alias CodexWrapper.Commands.McpServer
+  alias CodexWrapper.Config
+
+  describe "start/1" do
+    test "builds basic mcp-server args" do
+      config = Config.new(binary: "echo")
+      assert {:ok, output} = McpServer.start(config)
+      assert output =~ "mcp-server"
+    end
+  end
+
+  describe "start/2" do
+    test "builds args with config overrides" do
+      config = Config.new(binary: "echo")
+      assert {:ok, output} = McpServer.start(config, config: ["model=\"gpt-5\""])
+      assert output =~ "mcp-server"
+      assert output =~ "-c"
+      assert output =~ "model=\"gpt-5\""
+    end
+
+    test "builds args with enable flags" do
+      config = Config.new(binary: "echo")
+      assert {:ok, output} = McpServer.start(config, enable: ["web-search"])
+      assert output =~ "mcp-server"
+      assert output =~ "--enable"
+      assert output =~ "web-search"
+    end
+
+    test "builds args with disable flags" do
+      config = Config.new(binary: "echo")
+      assert {:ok, output} = McpServer.start(config, disable: ["web-search"])
+      assert output =~ "mcp-server"
+      assert output =~ "--disable"
+      assert output =~ "web-search"
+    end
+
+    test "builds args with all options" do
+      config = Config.new(binary: "echo")
+
+      assert {:ok, output} =
+               McpServer.start(config,
+                 config: ["model=\"gpt-5\""],
+                 enable: ["web-search"],
+                 disable: ["auto-update"]
+               )
+
+      assert output =~ "mcp-server"
+      assert output =~ "-c"
+      assert output =~ "model=\"gpt-5\""
+      assert output =~ "--enable"
+      assert output =~ "web-search"
+      assert output =~ "--disable"
+      assert output =~ "auto-update"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Done. Created `CodexWrapper.Commands.McpServer` with:

- `start/2` - wraps `codex mcp-server` with support for `:config` overrides (`-c key=value`), `:enable` and `:disable` feature flags
- 5 tests covering basic invocation, config overrides, enable/disable flags, and combined options

All 169 tests pass, no compilation warnings.

## Test results

Both checks pass:
- `mix compile --warnings-as-errors` — clean, no warnings
- `mix test` — 169 tests, 0 failures

No fixes needed.

---
Generated by arsenale | Cost: $0.52 | Closes #14