### PR TITLE
feat: hex.pm publish prep

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Josh Rotenberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ servers -- all from Elixir.
 ```elixir
 def deps do
   [
-    {:codex_wrapper_ex, "~> 0.1.0"}
+    {:codex_wrapper, "~> 0.1.0"}
   ]
 end
 ```

--- a/lib/codex_wrapper.ex
+++ b/lib/codex_wrapper.ex
@@ -86,7 +86,7 @@ defmodule CodexWrapper do
 
   ## Options
 
-  Config options (passed to `Config.new/1`):
+  Config options (passed to `CodexWrapper.Config.new/1`):
     * `:binary` - Path to codex binary
     * `:working_dir` - Working directory
     * `:env` - Environment variables
@@ -163,7 +163,7 @@ defmodule CodexWrapper do
 
   ## Options
 
-  Config options (passed to `Config.new/1`):
+  Config options (passed to `CodexWrapper.Config.new/1`):
     * `:binary` - Path to codex binary
     * `:working_dir` - Working directory
     * `:env` - Environment variables

--- a/mix.exs
+++ b/mix.exs
@@ -6,13 +6,14 @@ defmodule CodexWrapperEx.MixProject do
 
   def project do
     [
-      app: :codex_wrapper_ex,
+      app: :codex_wrapper,
       version: @version,
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: docs(),
-      name: "CodexWrapperEx",
+      package: package(),
+      name: "CodexWrapper",
       description: "Elixir wrapper for the Codex CLI"
     ]
   end
@@ -35,6 +36,15 @@ defmodule CodexWrapperEx.MixProject do
     [
       main: "CodexWrapper",
       source_url: @source_url
+    ]
+  end
+
+  defp package do
+    [
+      licenses: ["MIT"],
+      links: %{"GitHub" => @source_url},
+      files: ~w(lib mix.exs README.md LICENSE .formatter.exs),
+      maintainers: ["Josh Rotenberg"]
     ]
   end
 end


### PR DESCRIPTION
## Summary

Done. Here's what was changed:

- **mix.exs**: Renamed `app` from `:codex_wrapper_ex` to `:codex_wrapper`, updated `name` to `"CodexWrapper"`, added `package/0` with licenses, links, files list, and maintainers
- **LICENSE**: Created MIT license file
- **README.md**: Updated dep name from `:codex_wrapper_ex` to `:codex_wrapper`
- **lib/codex_wrapper.ex**: Fixed doc references from `Config.new/1` to `CodexWrapper.Config.new/1` (eliminated ExDoc warnings)

All validations pass: 217 tests, `mix com

## Test results

All checks pass:

- **`mix test`**: 217 tests, 0 failures
- **`mix compile --warnings-as-errors`**: Clean compilation, no warnings

No fixes needed.

---
Generated by arsenale | Cost: $1.11 | Closes #17