### PR TITLE
docs: add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # CodexWrapperEx
 
 [![CI](https://github.com/joshrotenberg/codex_wrapper_ex/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/codex_wrapper_ex/actions/workflows/ci.yml)
+[![Hex.pm](https://img.shields.io/hexpm/v/codex_wrapper.svg)](https://hex.pm/packages/codex_wrapper)
+[![Hex.pm Downloads](https://img.shields.io/hexpm/dt/codex_wrapper.svg)](https://hex.pm/packages/codex_wrapper)
+[![Docs](https://img.shields.io/badge/hex-docs-blue.svg)](https://hexdocs.pm/codex_wrapper)
+[![License](https://img.shields.io/hexpm/l/codex_wrapper.svg)](https://github.com/joshrotenberg/codex_wrapper_ex/blob/main/LICENSE)
 
 Elixir wrapper for the [Codex CLI](https://github.com/openai/codex).
 


### PR DESCRIPTION
## Summary

Done. Added the following badges to README.md:

- **CI** (already existed)
- **Hex.pm version** -- links to hex.pm/packages/codex_wrapper
- **Hex.pm downloads** -- total download count
- **Docs** -- links to hexdocs.pm/codex_wrapper
- **License** -- pulls license from Hex metadata

All tests pass (217/217), compilation clean. Committed on `arsenale/26-docs-add-badges-to-readme`.

## Test results

Both checks pass:

- **`mix test`**: 217 tests, 0 failures
- **`mix compile --warnings-as-errors`**: Clean compilation, no warnings

No fixes needed.

---
Generated by arsenale | Cost: $0.28 | Closes #26