### PR TITLE
fix: version test fails in CI (codex not installed)

### DIFF
--- a/test/codex_wrapper/commands/version_test.exs
+++ b/test/codex_wrapper/commands/version_test.exs
@@ -4,9 +4,11 @@ defmodule CodexWrapper.Commands.VersionTest do
   alias CodexWrapper.Commands.Version
   alias CodexWrapper.Config
 
+  @fake_codex Path.expand("../../fixtures/fake_codex.sh", __DIR__)
+
   describe "execute/1" do
     test "returns version map" do
-      config = Config.new(binary: "echo")
+      config = Config.new(binary: @fake_codex)
       assert {:ok, %{version: version, raw: raw}} = Version.execute(config)
       assert version =~ "--version"
       assert raw == version

--- a/test/fixtures/fake_codex.sh
+++ b/test/fixtures/fake_codex.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Fake codex binary for testing.
+# Echoes all arguments so tests can verify correct arg construction.
+printf '%s\n' "$*"


### PR DESCRIPTION
## Summary

Done. The fix:

- **Root cause**: GNU `echo` (used on Ubuntu CI) interprets `--version` as a flag and outputs coreutils version info instead of the literal string `--version`. macOS `/bin/echo` doesn't, so the test only fails in CI.
- **Fix**: Added `test/fixtures/fake_codex.sh` — a portable shell script using `printf` that echoes all args verbatim. Updated the version test to use this fixture instead of `echo`.

## Test results

All checks pass:

- **`mix test`**: 217 tests, 0 failures
- **`mix compile --warnings-as-errors`**: Clean compilation, no warnings

No fixes needed.

---
Generated by arsenale | Cost: $0.75 | Closes #27