### PR TITLE
fix: version test fails in CI (codex not installed)

### DIFF
--- a/test/codex_wrapper/commands/version_test.exs
+++ b/test/codex_wrapper/commands/version_test.exs
@@ -4,11 +4,13 @@ defmodule CodexWrapper.Commands.VersionTest do
   alias CodexWrapper.Commands.Version
   alias CodexWrapper.Config
 
+  @fake_codex Path.expand("../../fixtures/fake_codex.sh", __DIR__)
+
   describe "execute/1" do
     test "returns version map" do
-      config = Config.new(binary: "echo")
+      config = Config.new(binary: @fake_codex)
       assert {:ok, %{version: version, raw: raw}} = Version.execute(config)
-      assert version =~ "--version"
+      assert version == "codex 0.1.0"
       assert raw == version
     end
   end

--- a/test/fixtures/fake_codex.sh
+++ b/test/fixtures/fake_codex.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Fake codex binary for unit tests.
+# Echoes arguments so tests can assert on them.
+# Special-cases --version to return a realistic version string.
+
+for arg in "$@"; do
+  if [ "$arg" = "--version" ]; then
+    echo "codex 0.1.0"
+    exit 0
+  fi
+done
+
+echo "$@"


### PR DESCRIPTION
## Summary

Done. The fix:

- **`test/fixtures/fake_codex.sh`** — new fixture script that outputs `codex 0.1.0` when passed `--version`, giving deterministic output across platforms
- **`test/codex_wrapper/commands/version_test.exs`** — uses the fixture script instead of `echo`, which behaves differently on Linux (GNU coreutils) vs macOS

## Test results

All checks pass:

- **`mix test`**: 217 tests, 0 failures
- **`mix compile --warnings-as-errors`**: clean compilation, no warnings

No fixes needed.

---
Generated by arsenale | Cost: $0.44 | Closes #27