### PR TITLE
fix: close stdin on streaming Port paths

### DIFF
--- a/lib/codex_wrapper/command.ex
+++ b/lib/codex_wrapper/command.ex
@@ -44,12 +44,13 @@ defmodule CodexWrapper.Command do
     cd = Keyword.get(opts, :cd)
     env = Keyword.get(opts, :env, [])
 
-    # Build the command string with stdin redirected from /dev/null
-    escaped_args = Enum.map_join(args, " ", &shell_escape/1)
-    shell_cmd = "#{binary} #{escaped_args} < /dev/null 2>&1"
-
     port_opts =
-      [:binary, :exit_status, :stderr_to_stdout, args: ["-c", shell_cmd]]
+      [
+        :binary,
+        :exit_status,
+        :stderr_to_stdout,
+        args: shell_cmd_args(binary, args, capture_stderr: true)
+      ]
       |> maybe_add(:cd, cd)
       |> maybe_add_env(env)
 
@@ -67,7 +68,26 @@ defmodule CodexWrapper.Command do
     end
   end
 
-  defp shell_escape(arg) do
+  # Build the `:args` list for a `Port.open({:spawn_executable, "/bin/sh"}, ...)`
+  # call that runs `binary` with `args` and redirects stdin from `/dev/null`.
+  # Shared by the execute path (`run/3`) and the streaming paths
+  # (`Exec.stream/2`, `ExecResume.stream/2`) so the stdin-closing
+  # mechanism lives in one place.
+  #
+  # Pass `capture_stderr: true` to merge stderr into stdout (execute path
+  # collects all output before parsing). Leave it off for streaming so
+  # stderr flows to the parent's stderr without contaminating NDJSON on stdout.
+  @doc false
+  @spec shell_cmd_args(String.t(), [String.t()], keyword()) :: [String.t()]
+  def shell_cmd_args(binary, args, opts \\ []) do
+    escaped_args = Enum.map_join(args, " ", &shell_escape/1)
+    redirect = if Keyword.get(opts, :capture_stderr, false), do: " 2>&1", else: ""
+    shell_cmd = "#{binary} #{escaped_args} < /dev/null#{redirect}"
+    ["-c", shell_cmd]
+  end
+
+  @doc false
+  def shell_escape(arg) do
     if String.contains?(arg, ["'", " ", "\"", "\\", "(", ")", "$", "`", "!", "&", "|", ";", "\n"]) do
       "'" <> String.replace(arg, "'", "'\\''") <> "'"
     else

--- a/lib/codex_wrapper/exec.ex
+++ b/lib/codex_wrapper/exec.ex
@@ -189,15 +189,16 @@ defmodule CodexWrapper.Exec do
   def stream(%__MODULE__{} = exec, %Config{} = config) do
     exec = %{exec | json: true}
     args = Config.base_args(config) ++ args(exec)
+    shell_args = Command.shell_cmd_args(config.binary, args)
 
     port_opts =
-      [:binary, :exit_status, {:line, 1_048_576}, {:args, args}] ++
+      [:binary, :exit_status, {:line, 1_048_576}, {:args, shell_args}] ++
         port_env_opts(config) ++
         port_cd_opts(config)
 
     Stream.resource(
       fn ->
-        Port.open({:spawn_executable, config.binary}, port_opts)
+        Port.open({:spawn_executable, "/bin/sh"}, port_opts)
       end,
       fn port ->
         receive do

--- a/lib/codex_wrapper/exec_resume.ex
+++ b/lib/codex_wrapper/exec_resume.ex
@@ -171,15 +171,16 @@ defmodule CodexWrapper.ExecResume do
   def stream(%__MODULE__{} = exec, %Config{} = config) do
     exec = %{exec | json: true}
     args = Config.base_args(config) ++ args(exec)
+    shell_args = Command.shell_cmd_args(config.binary, args)
 
     port_opts =
-      [:binary, :exit_status, {:line, 1_048_576}, {:args, args}] ++
+      [:binary, :exit_status, {:line, 1_048_576}, {:args, shell_args}] ++
         port_env_opts(config) ++
         port_cd_opts(config)
 
     Stream.resource(
       fn ->
-        Port.open({:spawn_executable, config.binary}, port_opts)
+        Port.open({:spawn_executable, "/bin/sh"}, port_opts)
       end,
       fn port ->
         receive do


### PR DESCRIPTION
## Summary

- Fix Port-based streaming (`Exec.stream/2`, `ExecResume.stream/2`) hanging indefinitely against `codex-cli ≥ 0.118` because the Port inherited stdin from the parent and Codex reads stdin at startup.
- Extract the shell-wrap-and-close-stdin mechanism from `Command.run_with_closed_stdin` into a shared `Command.shell_cmd_args/3` helper so execute and streaming paths share one implementation.
- Streaming opts out of the `2>&1` stderr merge that the execute path uses, so stderr flows to the parent's stderr without contaminating NDJSON on stdout.

Closes #37. Complements #34 which fixed the same root cause in `command.ex` (the non-streaming `execute` path) but didn't touch the streaming paths.

## Test plan

- [x] `mix test` — 217 tests pass, no regressions
- [x] **Live verification against `codex-cli 0.119.0`**:
  ```
  Calling Exec.stream/2 ...
  Stream completed in 13094ms with 4 events.
  Event types: ["thread.started", "turn.started", "item.completed", "turn.completed"]
  SUCCESS: saw turn.completed
  ```
  Previously this call hung until the internal `after 300_000` safety timeout fired with zero events.
- [x] The `Reading additional input from stdin...` message from Codex no longer appears, confirming stdin is actually closed.

## Background

Discovered while building a `GenAgent` backend adapter on top of this package. The GenAgent Codex backend currently uses the non-streaming `exec_json` path (which was already fixed by #34), so this fix doesn't unblock anything immediately for that consumer — but any future streaming consumer would have hit the same wall. Getting the streaming path into the same state as execute makes the package's surface consistent.

There is a sibling issue on `claude_wrapper_ex` ([#42](https://github.com/joshrotenberg/claude_wrapper_ex/issues/42)) with the same latent root cause — the Claude CLI doesn't currently trigger it, but the code path is structurally identical. Fix PR to follow there.