### PR TITLE
fix: extract thread_id from Codex events for Session.send multi-turn

### DIFF
--- a/lib/codex_wrapper/session.ex
+++ b/lib/codex_wrapper/session.ex
@@ -254,9 +254,16 @@ defmodule CodexWrapper.Session do
     ExecResume.stream(exec_resume, session.config)
   end
 
-  defp extract_session_id(events) do
+  # Public with @doc false so the session-id-capture logic can be covered
+  # by regression tests — see SessionTest `describe "extract_session_id/1"`.
+  # Codex 0.119+ emits the thread identifier as `"thread_id"` in the first
+  # `thread.started` event. Older versions (or other forks) may still use
+  # `"session_id"`, so we check both.
+  @doc false
+  @spec extract_session_id([JsonLineEvent.t()]) :: String.t() | nil
+  def extract_session_id(events) do
     Enum.find_value(events, fn event ->
-      JsonLineEvent.get(event, "session_id")
+      JsonLineEvent.get(event, "thread_id") || JsonLineEvent.get(event, "session_id")
     end)
   end
 

--- a/test/codex_wrapper/session_test.exs
+++ b/test/codex_wrapper/session_test.exs
@@ -1,7 +1,9 @@
 defmodule CodexWrapper.SessionTest do
   use ExUnit.Case, async: true
 
-  alias CodexWrapper.{Config, Session}
+  alias CodexWrapper.{Config, JsonLineEvent, Session}
+
+  defp event(type, data), do: %JsonLineEvent{event_type: type, data: data, raw: ""}
 
   describe "new/2" do
     test "creates session with config" do
@@ -86,6 +88,51 @@ defmodule CodexWrapper.SessionTest do
       config = Config.new()
       session = Session.new(config)
       assert Session.history(session) == Session.turns(session)
+    end
+  end
+
+  describe "extract_session_id/1" do
+    test "extracts thread_id from a thread.started event" do
+      events = [
+        event("thread.started", %{"thread_id" => "019d799c-09f1-7ea0-8e5a-7b42a640c103"}),
+        event("turn.started", %{}),
+        event("turn.completed", %{"usage" => %{"input_tokens" => 10, "output_tokens" => 2}})
+      ]
+
+      assert Session.extract_session_id(events) == "019d799c-09f1-7ea0-8e5a-7b42a640c103"
+    end
+
+    test "falls back to session_id if thread_id is absent" do
+      # Defensive path: older Codex versions or forks that may not emit thread_id.
+      events = [
+        event("result", %{"session_id" => "legacy-sid-123"})
+      ]
+
+      assert Session.extract_session_id(events) == "legacy-sid-123"
+    end
+
+    test "prefers thread_id when both are present" do
+      events = [
+        event("thread.started", %{
+          "thread_id" => "new-thread",
+          "session_id" => "old-sid"
+        })
+      ]
+
+      assert Session.extract_session_id(events) == "new-thread"
+    end
+
+    test "returns nil when neither thread_id nor session_id is present" do
+      events = [
+        event("turn.started", %{}),
+        event("turn.completed", %{"usage" => %{"input_tokens" => 1, "output_tokens" => 1}})
+      ]
+
+      assert Session.extract_session_id(events) == nil
+    end
+
+    test "returns nil for an empty event list" do
+      assert Session.extract_session_id([]) == nil
     end
   end
 end


### PR DESCRIPTION
## Summary

- Fix `Session.send/3` silently dropping conversation history on every follow-up turn against `codex-cli ≥ 0.119`. `extract_session_id/1` was looking up `"session_id"` in events, but Codex emits its thread identifier as `"thread_id"` in the first `thread.started` event. The captured id was always `nil`, `new_session_id` fell through to the stored (nil) `session.session_id`, and the next call to `Session.send/3` dispatched a fresh `Exec` (not `ExecResume`) with no memory of prior turns.
- Change the lookup to prefer `"thread_id"`, fall back to `"session_id"` for defensive compatibility with older Codex versions or forks.
- Expose `extract_session_id/1` with `@doc false` so the capture logic can be covered by unit tests (same pattern as `Command.shell_cmd_args/3`).

Closes #40.

## Test plan

- [x] `mix test` — 222 tests pass (5 new regression tests for `extract_session_id/1`)
- [x] `mix dialyzer` — clean
- [x] **Live multi-turn verification against `codex-cli 0.119.0`**:
  ```
  --- Turn 1 ---
  session_id after turn 1: "019d79cf-c221-7702-924a-b10fd5a77b44"
  result1 stdout first line: {"type":"thread.started","thread_id":"019d79cf-c221-7702-924a-b10fd5a77b44"}

  --- Turn 2 ---
  result2 stdout: {"type":"thread.started","thread_id":"019d79cf-c221-7702-924a-b10fd5a77b44"}
  {"type":"turn.started"}
  {"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"42"}}
  {"type":"turn.completed","usage":{"input_tokens":27980,"cached_input_tokens":18304,"output_tokens":33}}

  SUCCESS: turn 2 remembered the number 42 -> multi-turn via Session.send works
  ```
  Before this fix: `session_id` was `nil` after turn 1, and turn 2 ran as a fresh thread with no knowledge of the number.
  After this fix: `session_id` is a real thread id after turn 1, turn 2 emits the same thread id in its `thread.started` event (confirming Codex resumed the existing thread), and the assistant correctly answered "42".

## Regression tests

New `describe "extract_session_id/1"` block in `test/codex_wrapper/session_test.exs` covers:

- `thread_id` extracted from `thread.started`
- `session_id` fallback when `thread_id` is absent
- `thread_id` preferred when both are present
- `nil` when neither is present
- `nil` on an empty event list

## Background

Discovered while filing [#40](https://github.com/joshrotenberg/codex_wrapper_ex/issues/40) as a follow-up to the `chore/add-dialyxir` work — see the `Session.stream/3` fix in [#36](https://github.com/joshrotenberg/codex_wrapper_ex/pull/36). The two functions had the same underlying field-name bug, but only `Session.stream/3` was visible to dialyzer because of the `make_ref()` type abuse. `Session.send/3` compiled cleanly but failed at runtime without any indication.