### PR TITLE
fix: update source URL to genagent org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # CodexWrapperEx
 
-[![CI](https://github.com/joshrotenberg/codex_wrapper_ex/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/codex_wrapper_ex/actions/workflows/ci.yml)
+[![CI](https://github.com/genagent/codex_wrapper_ex/actions/workflows/ci.yml/badge.svg)](https://github.com/genagent/codex_wrapper_ex/actions/workflows/ci.yml)
 [![Hex.pm](https://img.shields.io/hexpm/v/codex_wrapper.svg)](https://hex.pm/packages/codex_wrapper)
 [![Hex.pm Downloads](https://img.shields.io/hexpm/dt/codex_wrapper.svg)](https://hex.pm/packages/codex_wrapper)
 [![Docs](https://img.shields.io/badge/hex-docs-blue.svg)](https://hexdocs.pm/codex_wrapper)
-[![License](https://img.shields.io/hexpm/l/codex_wrapper.svg)](https://github.com/joshrotenberg/codex_wrapper_ex/blob/main/LICENSE)
+[![License](https://img.shields.io/hexpm/l/codex_wrapper.svg)](https://github.com/genagent/codex_wrapper_ex/blob/main/LICENSE)
 
 Elixir wrapper for the [Codex CLI](https://github.com/openai/codex).
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule CodexWrapperEx.MixProject do
   use Mix.Project
 
   @version "0.2.2"
-  @source_url "https://github.com/joshrotenberg/codex_wrapper_ex"
+  @source_url "https://github.com/genagent/codex_wrapper_ex"
 
   def project do
     [


### PR DESCRIPTION
## Summary

Repository moved from \`joshrotenberg/codex_wrapper_ex\` to
\`genagent/codex_wrapper_ex\` as part of consolidating the
GenAgent ecosystem under a dedicated org. Update package
metadata and README badges so the next published release
reflects the canonical location.

## Files

- \`mix.exs\`: \`@source_url\` (used by docs \`source_url\` and
  package \`links:\`)
- \`README.md\`: CI badge URL and License badge URL

## Why a patch release?

GitHub auto-redirects from the old URL, so existing published
versions remain reachable and there's no user-visible break.
But the stale URL is baked into the hex package metadata for
v0.2.2 -- the only way to correct it is to publish a new
version. Using \`fix:\` prefix so release-please cuts 0.2.3.