### PR TITLE
docs: replace em dashes with double hyphens

### DIFF
--- a/lib/codex_wrapper/commands/apply.ex
+++ b/lib/codex_wrapper/commands/apply.ex
@@ -1,6 +1,6 @@
 defmodule CodexWrapper.Commands.Apply do
   @moduledoc """
-  Apply command — apply an agent diff as git apply.
+  Apply command -- apply an agent diff as git apply.
 
   Wraps `codex apply <task-id>`.
 

--- a/lib/codex_wrapper/commands/auth.ex
+++ b/lib/codex_wrapper/commands/auth.ex
@@ -1,6 +1,6 @@
 defmodule CodexWrapper.Commands.Auth do
   @moduledoc """
-  Authentication commands — login, logout, status.
+  Authentication commands -- login, logout, status.
 
   Wraps `codex login`, `codex logout`, and `codex login status`.
   """

--- a/lib/codex_wrapper/commands/fork.ex
+++ b/lib/codex_wrapper/commands/fork.ex
@@ -1,6 +1,6 @@
 defmodule CodexWrapper.Commands.Fork do
   @moduledoc """
-  Fork command — fork an existing session to try a different approach.
+  Fork command -- fork an existing session to try a different approach.
 
   Wraps `codex fork [session-id] [prompt]` with the full set of CLI flags.
 

--- a/lib/codex_wrapper/commands/sandbox.ex
+++ b/lib/codex_wrapper/commands/sandbox.ex
@@ -1,6 +1,6 @@
 defmodule CodexWrapper.Commands.Sandbox do
   @moduledoc """
-  Sandbox command — run a command inside the Codex sandbox.
+  Sandbox command -- run a command inside the Codex sandbox.
 
   Wraps `codex sandbox <platform> -- <command> [args...]`.
 

--- a/lib/codex_wrapper/commands/version.ex
+++ b/lib/codex_wrapper/commands/version.ex
@@ -1,6 +1,6 @@
 defmodule CodexWrapper.Commands.Version do
   @moduledoc """
-  Version command — parse `codex --version` output.
+  Version command -- parse `codex --version` output.
   """
 
   alias CodexWrapper.Config

--- a/lib/codex_wrapper/exec.ex
+++ b/lib/codex_wrapper/exec.ex
@@ -1,6 +1,6 @@
 defmodule CodexWrapper.Exec do
   @moduledoc """
-  Exec command — the primary interface for non-interactive prompts.
+  Exec command -- the primary interface for non-interactive prompts.
 
   Wraps `codex exec <prompt>` with the full set of CLI flags.
 

--- a/lib/codex_wrapper/exec_resume.ex
+++ b/lib/codex_wrapper/exec_resume.ex
@@ -1,6 +1,6 @@
 defmodule CodexWrapper.ExecResume do
   @moduledoc """
-  ExecResume command — resume an existing session non-interactively.
+  ExecResume command -- resume an existing session non-interactively.
 
   Wraps `codex exec resume [session_id] [prompt]` with the full set of CLI flags.
 

--- a/lib/codex_wrapper/json_line_event.ex
+++ b/lib/codex_wrapper/json_line_event.ex
@@ -8,10 +8,10 @@ defmodule CodexWrapper.JsonLineEvent do
   ## Event types
 
   Common event types include:
-  - `"thread.started"` — thread initialization
-  - `"turn.started"` — turn began
-  - `"item.completed"` — item completed
-  - `"turn.completed"` — turn finished
+  - `"thread.started"` -- thread initialization
+  - `"turn.started"` -- turn began
+  - `"item.completed"` -- item completed
+  - `"turn.completed"` -- turn finished
   """
 
   @type t :: %__MODULE__{

--- a/lib/codex_wrapper/result.ex
+++ b/lib/codex_wrapper/result.ex
@@ -2,7 +2,7 @@ defmodule CodexWrapper.Result do
   @moduledoc """
   Result from a completed exec command.
 
-  Maps to the Rust `CommandOutput` — the raw output from `System.cmd`.
+  Maps to the Rust `CommandOutput` -- the raw output from `System.cmd`.
   """
 
   @type t :: %__MODULE__{

--- a/lib/codex_wrapper/review.ex
+++ b/lib/codex_wrapper/review.ex
@@ -1,6 +1,6 @@
 defmodule CodexWrapper.Review do
   @moduledoc """
-  Review command — code review with git integration.
+  Review command -- code review with git integration.
 
   Wraps `codex exec review` with review-specific CLI flags.
 

--- a/lib/codex_wrapper/session.ex
+++ b/lib/codex_wrapper/session.ex
@@ -98,7 +98,7 @@ defmodule CodexWrapper.Session do
   Send a message and return a stream of events.
 
   Returns `{session, stream}`. The returned `session` is the **same
-  session passed in** — this function does *not* thread `session_id`
+  session passed in** -- this function does *not* thread `session_id`
   across turns. If you need multi-turn continuity, use `send/3`
   instead, which runs the turn synchronously and updates `session_id`
   from the final events.
@@ -255,7 +255,7 @@ defmodule CodexWrapper.Session do
   end
 
   # Public with @doc false so the session-id-capture logic can be covered
-  # by regression tests — see SessionTest `describe "extract_session_id/1"`.
+  # by regression tests -- see SessionTest `describe "extract_session_id/1"`.
   # Codex 0.119+ emits the thread identifier as `"thread_id"` in the first
   # `thread.started` event. Older versions (or other forks) may still use
   # `"session_id"`, so we check both.


### PR DESCRIPTION
## Summary

- Mechanical sweep: 15 em dashes across 11 files in `lib/` replaced with `--` to match house style (no em dashes in docs or code comments).
- Purely typographic; every hit was an aside/separator in a moduledoc, inline comment, or event-type description. No sentence structure or behavior changes.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict`
- [x] `mix test` (222 tests, 0 failures)