### PR TITLE
fix: rewrite Commands.Sandbox for the flat codex sandbox CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,10 +265,25 @@ Run commands inside Codex's sandbox:
 ```elixir
 alias CodexWrapper.Commands.Sandbox
 
-Sandbox.new(:macos, "python3")
+Sandbox.new("python3")
 |> Sandbox.args(["script.py", "--flag"])
 |> Sandbox.execute(config)
 ```
+
+Sandbox state and permission profiles:
+
+```elixir
+Sandbox.new("pytest")
+|> Sandbox.permission_profile("ci")
+|> Sandbox.sandbox_state_readable_root("/usr/share")
+|> Sandbox.sandbox_state_disable_network()
+|> Sandbox.cd("/src")
+|> Sandbox.execute(config)
+```
+
+`Sandbox.new/1` replaces the old `Sandbox.new(platform, command)`. The
+Codex CLI dropped the platform subcommand and infers the platform from
+the host, so passing an atom now raises with a migration message.
 
 ## Shell completions
 

--- a/lib/codex_wrapper/commands/sandbox.ex
+++ b/lib/codex_wrapper/commands/sandbox.ex
@@ -2,39 +2,82 @@ defmodule CodexWrapper.Commands.Sandbox do
   @moduledoc """
   Sandbox command -- run a command inside the Codex sandbox.
 
-  Wraps `codex sandbox <platform> -- <command> [args...]`.
+  Wraps `codex sandbox [OPTIONS] [COMMAND]...`.
+
+  The platform is no longer part of the invocation. Codex used to take it
+  as a subcommand (`codex sandbox macos -- ls`); as of codex-cli 0.14x the
+  command is flat and the platform is inferred from the host, so
+  `new/1` takes the command directly. See #56.
 
   ## Usage
 
       config = CodexWrapper.Config.new()
 
-      # Run ls inside a macOS sandbox
-      sandbox = CodexWrapper.Commands.Sandbox.new(:macos, "ls")
+      sandbox =
+        CodexWrapper.Commands.Sandbox.new("ls")
         |> CodexWrapper.Commands.Sandbox.arg("-la")
 
       {:ok, output} = CodexWrapper.Commands.Sandbox.execute(sandbox, config)
+
+  ## Sandbox state
+
+  The sandbox-state options configure what the sandboxed process can
+  reach. They are independent of the `:permission_profile`, which selects
+  a named profile from the Codex config:
+
+      CodexWrapper.Commands.Sandbox.new("pytest")
+      |> CodexWrapper.Commands.Sandbox.permission_profile("ci")
+      |> CodexWrapper.Commands.Sandbox.sandbox_state_readable_root("/usr/share")
+      |> CodexWrapper.Commands.Sandbox.sandbox_state_disable_network()
   """
 
-  alias CodexWrapper.Config
+  @behaviour CodexWrapper.Command
 
-  @type platform :: :macos | :linux | :windows
+  alias CodexWrapper.{Command, Config}
 
   @type t :: %__MODULE__{
-          platform: platform(),
           command: String.t(),
-          command_args: [String.t()]
+          command_args: [String.t()],
+          permission_profile: String.t() | nil,
+          sandbox_state_json: String.t() | nil,
+          sandbox_state_readable_roots: [String.t()],
+          sandbox_state_disable_network: boolean(),
+          cd: String.t() | nil
         }
 
-  defstruct [:platform, :command, command_args: []]
+  defstruct [
+    :command,
+    :permission_profile,
+    :sandbox_state_json,
+    :cd,
+    command_args: [],
+    sandbox_state_readable_roots: [],
+    sandbox_state_disable_network: false
+  ]
 
   # --- Constructor ---
 
   @doc """
-  Create a sandbox command for the given platform and command.
+  Create a sandbox command for the given command.
   """
-  @spec new(platform(), String.t()) :: t()
-  def new(platform, command) when platform in [:macos, :linux, :windows] and is_binary(command) do
-    %__MODULE__{platform: platform, command: command}
+  @spec new(String.t()) :: t()
+  def new(command) when is_binary(command) do
+    %__MODULE__{command: command}
+  end
+
+  @doc false
+  # `codex sandbox <platform>` was removed upstream. Raise rather than
+  # ignore the platform, so callers on the old API get a migration
+  # message instead of a silently different invocation.
+  @spec new(atom(), String.t()) :: no_return()
+  def new(platform, command) when is_atom(platform) and is_binary(command) do
+    raise ArgumentError, """
+    CodexWrapper.Commands.Sandbox.new/2 took a platform atom, which the Codex CLI no longer accepts.
+
+    Use new/1 instead; the platform is inferred from the host:
+
+        CodexWrapper.Commands.Sandbox.new(#{inspect(command)})
+    """
   end
 
   # --- Builder functions ---
@@ -48,6 +91,38 @@ defmodule CodexWrapper.Commands.Sandbox do
   def args(%__MODULE__{} = s, args) when is_list(args),
     do: %{s | command_args: s.command_args ++ args}
 
+  @doc "Select a named permission profile (`--permission-profile`)."
+  @spec permission_profile(t(), String.t()) :: t()
+  def permission_profile(%__MODULE__{} = s, profile) when is_binary(profile),
+    do: %{s | permission_profile: profile}
+
+  @doc "Path to a sandbox state JSON file (`--sandbox-state-json`)."
+  @spec sandbox_state_json(t(), String.t()) :: t()
+  def sandbox_state_json(%__MODULE__{} = s, path) when is_binary(path),
+    do: %{s | sandbox_state_json: path}
+
+  @doc """
+  Grant read access to a root (`--sandbox-state-readable-root`).
+
+  Accumulates: call once per root.
+  """
+  @spec sandbox_state_readable_root(t(), String.t()) :: t()
+  def sandbox_state_readable_root(%__MODULE__{} = s, root) when is_binary(root),
+    do: %{s | sandbox_state_readable_roots: s.sandbox_state_readable_roots ++ [root]}
+
+  @doc "Disable network access inside the sandbox (`--sandbox-state-disable-network`)."
+  @spec sandbox_state_disable_network(t()) :: t()
+  def sandbox_state_disable_network(%__MODULE__{} = s),
+    do: %{s | sandbox_state_disable_network: true}
+
+  @doc """
+  Working directory for the sandboxed command (`--cd`).
+
+  Distinct from `Config`'s `:working_dir`, which sets the subprocess cwd.
+  """
+  @spec cd(t(), String.t()) :: t()
+  def cd(%__MODULE__{} = s, dir) when is_binary(dir), do: %{s | cd: dir}
+
   # --- Execution ---
 
   @doc """
@@ -55,12 +130,7 @@ defmodule CodexWrapper.Commands.Sandbox do
   """
   @spec execute(t(), Config.t()) :: {:ok, String.t()} | {:error, term()}
   def execute(%__MODULE__{} = sandbox, %Config{} = config) do
-    all_args = Config.base_args(config) ++ build_args(sandbox)
-
-    case System.cmd(config.binary, all_args, Config.cmd_opts(config)) do
-      {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
-    end
+    Command.run(__MODULE__, sandbox, config)
   end
 
   # --- Arg building ---
@@ -69,11 +139,32 @@ defmodule CodexWrapper.Commands.Sandbox do
   Build the argument list for this command.
   """
   @spec build_args(t()) :: [String.t()]
-  def build_args(%__MODULE__{} = s) do
-    ["sandbox", format_platform(s.platform), "--", s.command] ++ s.command_args
+  def build_args(%__MODULE__{} = s), do: args(s)
+
+  @impl true
+  def args(%__MODULE__{} = s) do
+    # `--` separates codex's own options from the sandboxed command, so a
+    # command with leading dashes is not parsed as a codex flag.
+    ["sandbox"]
+    |> add_opt("--permission-profile", s.permission_profile)
+    |> add_opt("--sandbox-state-json", s.sandbox_state_json)
+    |> add_list("--sandbox-state-readable-root", s.sandbox_state_readable_roots)
+    |> add_bool("--sandbox-state-disable-network", s.sandbox_state_disable_network)
+    |> add_opt("--cd", s.cd)
+    |> Kernel.++(["--", s.command])
+    |> Kernel.++(s.command_args)
   end
 
-  defp format_platform(:macos), do: "macos"
-  defp format_platform(:linux), do: "linux"
-  defp format_platform(:windows), do: "windows"
+  @impl true
+  def parse_output(stdout, 0), do: {:ok, String.trim(stdout)}
+  def parse_output(stdout, exit_code), do: {:error, {:exit, exit_code, stdout}}
+
+  # --- Arg helpers ---
+
+  defp add_opt(args, _flag, nil), do: args
+  defp add_opt(args, flag, value), do: args ++ [flag, value]
+  defp add_bool(args, _flag, false), do: args
+  defp add_bool(args, flag, true), do: args ++ [flag]
+  defp add_list(args, _flag, []), do: args
+  defp add_list(args, flag, values), do: args ++ Enum.flat_map(values, &[flag, &1])
 end

--- a/test/codex_wrapper/commands/sandbox_test.exs
+++ b/test/codex_wrapper/commands/sandbox_test.exs
@@ -3,70 +3,200 @@ defmodule CodexWrapper.Commands.SandboxTest do
 
   alias CodexWrapper.Commands.Sandbox
 
-  describe "new/2" do
-    test "creates sandbox with platform and command" do
-      sandbox = Sandbox.new(:macos, "ls")
-      assert sandbox.platform == :macos
+  describe "new/1" do
+    test "creates sandbox with the command" do
+      sandbox = Sandbox.new("ls")
       assert sandbox.command == "ls"
       assert sandbox.command_args == []
     end
 
-    test "accepts all platforms" do
-      assert Sandbox.new(:macos, "cmd").platform == :macos
-      assert Sandbox.new(:linux, "cmd").platform == :linux
-      assert Sandbox.new(:windows, "cmd").platform == :windows
+    test "defaults every option to unset" do
+      sandbox = Sandbox.new("ls")
+      assert sandbox.permission_profile == nil
+      assert sandbox.sandbox_state_json == nil
+      assert sandbox.sandbox_state_readable_roots == []
+      assert sandbox.sandbox_state_disable_network == false
+      assert sandbox.cd == nil
+    end
+  end
+
+  describe "new/2" do
+    test "raises with a migration message for the removed platform argument" do
+      assert_raise ArgumentError, ~r/no longer accepts/, fn ->
+        Sandbox.new(:macos, "ls")
+      end
+    end
+
+    test "names the new/1 replacement in the message" do
+      error = assert_raise ArgumentError, fn -> Sandbox.new(:linux, "cat") end
+      assert error.message =~ "Sandbox.new(\"cat\")"
     end
   end
 
   describe "builder functions" do
     test "arg/2 accumulates" do
-      sandbox = Sandbox.new(:macos, "ls") |> Sandbox.arg("-la") |> Sandbox.arg("/tmp")
+      sandbox = Sandbox.new("ls") |> Sandbox.arg("-la") |> Sandbox.arg("/tmp")
       assert sandbox.command_args == ["-la", "/tmp"]
     end
 
     test "args/2 adds multiple arguments" do
-      sandbox = Sandbox.new(:linux, "cat") |> Sandbox.args(["/etc/hosts", "/etc/passwd"])
+      sandbox = Sandbox.new("cat") |> Sandbox.args(["/etc/hosts", "/etc/passwd"])
       assert sandbox.command_args == ["/etc/hosts", "/etc/passwd"]
     end
 
     test "arg/2 and args/2 combine" do
       sandbox =
-        Sandbox.new(:macos, "ls")
+        Sandbox.new("ls")
         |> Sandbox.arg("-la")
         |> Sandbox.args(["/tmp", "/var"])
 
       assert sandbox.command_args == ["-la", "/tmp", "/var"]
     end
+
+    test "permission_profile/2 sets the profile" do
+      sandbox = Sandbox.new("ls") |> Sandbox.permission_profile("ci")
+      assert sandbox.permission_profile == "ci"
+    end
+
+    test "sandbox_state_json/2 sets the path" do
+      sandbox = Sandbox.new("ls") |> Sandbox.sandbox_state_json("/tmp/state.json")
+      assert sandbox.sandbox_state_json == "/tmp/state.json"
+    end
+
+    test "sandbox_state_readable_root/2 accumulates" do
+      sandbox =
+        Sandbox.new("ls")
+        |> Sandbox.sandbox_state_readable_root("/usr/share")
+        |> Sandbox.sandbox_state_readable_root("/opt")
+
+      assert sandbox.sandbox_state_readable_roots == ["/usr/share", "/opt"]
+    end
+
+    test "sandbox_state_disable_network/1 flips the flag" do
+      sandbox = Sandbox.new("ls") |> Sandbox.sandbox_state_disable_network()
+      assert sandbox.sandbox_state_disable_network
+    end
+
+    test "cd/2 sets the sandboxed working directory" do
+      assert Sandbox.new("ls") |> Sandbox.cd("/src") |> Map.fetch!(:cd) == "/src"
+    end
   end
 
   describe "build_args/1" do
-    test "macos sandbox" do
-      args = Sandbox.new(:macos, "ls") |> Sandbox.arg("-la") |> Sandbox.build_args()
-      assert args == ["sandbox", "macos", "--", "ls", "-la"]
+    test "bare command" do
+      assert Sandbox.build_args(Sandbox.new("whoami")) == ["sandbox", "--", "whoami"]
     end
 
-    test "linux sandbox" do
-      args = Sandbox.new(:linux, "cat") |> Sandbox.arg("/etc/hosts") |> Sandbox.build_args()
-      assert args == ["sandbox", "linux", "--", "cat", "/etc/hosts"]
-    end
-
-    test "windows sandbox" do
-      args = Sandbox.new(:windows, "dir") |> Sandbox.build_args()
-      assert args == ["sandbox", "windows", "--", "dir"]
-    end
-
-    test "no command args" do
-      args = Sandbox.new(:macos, "whoami") |> Sandbox.build_args()
-      assert args == ["sandbox", "macos", "--", "whoami"]
+    test "command with args" do
+      args = Sandbox.new("ls") |> Sandbox.arg("-la") |> Sandbox.build_args()
+      assert args == ["sandbox", "--", "ls", "-la"]
     end
 
     test "multiple command args" do
       args =
-        Sandbox.new(:linux, "grep")
+        Sandbox.new("grep")
         |> Sandbox.args(["-r", "pattern", "/src"])
         |> Sandbox.build_args()
 
-      assert args == ["sandbox", "linux", "--", "grep", "-r", "pattern", "/src"]
+      assert args == ["sandbox", "--", "grep", "-r", "pattern", "/src"]
+    end
+
+    test "no platform subcommand is emitted" do
+      args = Sandbox.build_args(Sandbox.new("ls"))
+      refute "macos" in args
+      refute "linux" in args
+      refute "windows" in args
+    end
+
+    test "permission profile" do
+      args = Sandbox.new("pytest") |> Sandbox.permission_profile("ci") |> Sandbox.build_args()
+      assert args == ["sandbox", "--permission-profile", "ci", "--", "pytest"]
+    end
+
+    test "sandbox state json" do
+      args =
+        Sandbox.new("ls") |> Sandbox.sandbox_state_json("/tmp/s.json") |> Sandbox.build_args()
+
+      assert args == ["sandbox", "--sandbox-state-json", "/tmp/s.json", "--", "ls"]
+    end
+
+    test "readable roots repeat the flag" do
+      args =
+        Sandbox.new("ls")
+        |> Sandbox.sandbox_state_readable_root("/usr/share")
+        |> Sandbox.sandbox_state_readable_root("/opt")
+        |> Sandbox.build_args()
+
+      assert args == [
+               "sandbox",
+               "--sandbox-state-readable-root",
+               "/usr/share",
+               "--sandbox-state-readable-root",
+               "/opt",
+               "--",
+               "ls"
+             ]
+    end
+
+    test "disable network is a bare flag" do
+      args = Sandbox.new("ls") |> Sandbox.sandbox_state_disable_network() |> Sandbox.build_args()
+      assert args == ["sandbox", "--sandbox-state-disable-network", "--", "ls"]
+    end
+
+    test "cd" do
+      args = Sandbox.new("ls") |> Sandbox.cd("/src") |> Sandbox.build_args()
+      assert args == ["sandbox", "--cd", "/src", "--", "ls"]
+    end
+
+    test "all options precede the -- separator" do
+      args =
+        Sandbox.new("pytest")
+        |> Sandbox.permission_profile("ci")
+        |> Sandbox.sandbox_state_json("/tmp/s.json")
+        |> Sandbox.sandbox_state_readable_root("/usr/share")
+        |> Sandbox.sandbox_state_disable_network()
+        |> Sandbox.cd("/src")
+        |> Sandbox.arg("-q")
+        |> Sandbox.build_args()
+
+      assert args == [
+               "sandbox",
+               "--permission-profile",
+               "ci",
+               "--sandbox-state-json",
+               "/tmp/s.json",
+               "--sandbox-state-readable-root",
+               "/usr/share",
+               "--sandbox-state-disable-network",
+               "--cd",
+               "/src",
+               "--",
+               "pytest",
+               "-q"
+             ]
+    end
+
+    test "a dash-leading command arg stays after the separator" do
+      args = Sandbox.new("ls") |> Sandbox.arg("--color=never") |> Sandbox.build_args()
+      assert List.last(args) == "--color=never"
+      assert Enum.at(args, -3) == "--"
+    end
+  end
+
+  describe "args/1 (Command behaviour)" do
+    test "matches build_args/1" do
+      sandbox = Sandbox.new("ls") |> Sandbox.permission_profile("ci") |> Sandbox.arg("-la")
+      assert Sandbox.args(sandbox) == Sandbox.build_args(sandbox)
+    end
+  end
+
+  describe "parse_output/2" do
+    test "trims stdout on a zero exit" do
+      assert Sandbox.parse_output("hello\n", 0) == {:ok, "hello"}
+    end
+
+    test "surfaces a non-zero exit with the output" do
+      assert Sandbox.parse_output("boom\n", 3) == {:error, {:exit, 3, "boom\n"}}
     end
   end
 end


### PR DESCRIPTION
Closes #56. First implementation slice of the Codex CLI 0.145.0 compatibility work tracked in #52.

## Problem

`CodexWrapper.Commands.Sandbox` wrapped `codex sandbox <platform> -- <command>`. codex-cli 0.14x removed the platform subcommand; `codex sandbox` now takes `[OPTIONS] [COMMAND]...` and infers the platform from the host.

The old invocation therefore passes the platform atom as the command to execute, and the CLI panics. The platform was baked into the constructor, so no arrangement of the previous API produced a valid invocation -- the module was broken outright rather than degraded.

## Changes

- `new/1` takes the command directly. `new/2` raises an `ArgumentError` naming the `new/1` replacement, rather than ignoring the platform and silently running a different command than the caller wrote.
- Builders for the new options: `permission_profile/2`, `sandbox_state_json/2`, `sandbox_state_readable_root/2` (accumulating, emits the flag once per root), `sandbox_state_disable_network/1`, `cd/2`.
- Execution routed through `Command.run/3` instead of `System.cmd/3`. The module was the odd one out; it now picks up the stdin-close behavior and the configured runner (including the forcola runner from #50) like `Exec` and friends.
- `--` still separates codex's own options from the sandboxed command, so a sandboxed command carrying its own flags is not parsed as codex flags. There is a test pinning that.

`parse_output/2` preserves the previous return shape, so callers see no change on the success path: `{:ok, trimmed}` on a zero exit, `{:error, {:exit, code, output}}` otherwise.

## Breaking

`Sandbox.new/2` no longer works. Targets the v0.5.0 breaking release alongside the rest of Phase 1 in #52.

```elixir
# before
Sandbox.new(:macos, "python3") |> Sandbox.args(["script.py"])

# after
Sandbox.new("python3") |> Sandbox.args(["script.py"])
```

## Note on `--sandbox-state-readable-root`

Modeled as repeatable (accumulating list, flag emitted per value). If upstream accepts it only once, calling the builder once still produces a correct invocation, so this is the lower-risk shape. Worth confirming against an authenticated CLI as part of the #52 verification checklist.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` (245 passed, 26 of them in the rewritten sandbox suite)
- [x] `mix dialyzer` (0 errors)
- [x] `mix docs`

`mix credo --strict` was not run locally: credo 1.7.17 crashes on Elixir 1.20.2 sigil tokens in a pre-existing test file. Local Elixir is 1.20.2; CI pins 1.19, where credo runs.

Arg-list tests cover each new flag individually, the combined ordering (all options before `--`), the absence of any platform subcommand, and a dash-leading command argument staying after the separator. No test drives the real `codex` binary.
