### PR TITLE
fix!: emit approval_policy as a -c config key, not --ask-for-approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,16 @@ config = Config.new(working_dir: "/path/to/project")
 Exec.new("Fix the tests")
 |> Exec.model("o3")
 |> Exec.sandbox(:workspace_write)
-|> Exec.approval_policy(:on_failure)
+|> Exec.approval_policy(:never)
 |> Exec.search()
 |> Exec.execute(config)
 ```
+
+`approval_policy/2` takes `:untrusted`, `:on_request`, or `:never`, and
+emits `-c approval_policy="<value>"`. The Codex CLI removed the
+`--ask-for-approval` flag from `exec` in 0.14x; the config key is the
+supported equivalent. `:on_failure` was dropped along with the flag and
+now raises.
 
 ## Review builder
 

--- a/lib/codex_wrapper.ex
+++ b/lib/codex_wrapper.ex
@@ -96,7 +96,7 @@ defmodule CodexWrapper do
   Exec options (passed to `Exec` builder):
     * `:model` - Model name
     * `:sandbox` - Sandbox mode atom
-    * `:approval_policy` - Approval policy atom
+    * `:approval_policy` - Approval policy atom (`:untrusted`, `:on_request`, `:never`)
     * `:full_auto` - Enable full-auto (boolean)
     * `:dangerously_bypass_approvals_and_sandbox` - Bypass all (boolean)
     * `:cd` - Working directory for codex subprocess

--- a/lib/codex_wrapper/exec.ex
+++ b/lib/codex_wrapper/exec.ex
@@ -23,7 +23,7 @@ defmodule CodexWrapper.Exec do
   alias CodexWrapper.{Command, Config, JsonLineEvent, Result}
 
   @type sandbox_mode :: :read_only | :workspace_write | :danger_full_access
-  @type approval_policy :: :untrusted | :on_failure | :on_request | :never
+  @type approval_policy :: :untrusted | :on_request | :never
 
   @type t :: %__MODULE__{
           prompt: String.t(),
@@ -87,9 +87,29 @@ defmodule CodexWrapper.Exec do
   @spec sandbox(t(), sandbox_mode()) :: t()
   def sandbox(%__MODULE__{} = e, mode), do: %{e | sandbox: mode}
 
-  @doc "Set the approval policy."
+  @doc """
+  Set the approval policy.
+
+  One of `:untrusted`, `:on_request`, or `:never`. Emitted as the
+  `-c approval_policy="<value>"` config override: codex-cli 0.14x removed
+  the `--ask-for-approval` flag from `exec`, and the config key is the
+  supported equivalent.
+
+  `:on_failure` was accepted by the old flag and is no longer a valid
+  policy; passing it raises.
+  """
   @spec approval_policy(t(), approval_policy()) :: t()
-  def approval_policy(%__MODULE__{} = e, policy), do: %{e | approval_policy: policy}
+  def approval_policy(%__MODULE__{}, :on_failure) do
+    raise ArgumentError, """
+    :on_failure is no longer a valid approval policy.
+
+    The Codex CLI dropped it along with the --ask-for-approval flag.
+    Valid policies are :untrusted, :on_request, and :never.
+    """
+  end
+
+  def approval_policy(%__MODULE__{} = e, policy) when policy in [:untrusted, :on_request, :never],
+    do: %{e | approval_policy: policy}
 
   @doc "Enable full-auto mode."
   @spec full_auto(t()) :: t()
@@ -234,13 +254,12 @@ defmodule CodexWrapper.Exec do
   @impl Command
   def args(%__MODULE__{} = e) do
     ["exec"]
-    |> add_list("-c", e.config_overrides)
+    |> add_list("-c", config_overrides(e))
     |> add_list("--enable", e.enabled_features)
     |> add_list("--disable", e.disabled_features)
     |> add_list("--image", e.images)
     |> add_opt("--model", e.model)
     |> add_opt("--sandbox", format_sandbox(e.sandbox))
-    |> add_opt("--ask-for-approval", format_approval_policy(e.approval_policy))
     |> add_bool("--full-auto", e.full_auto)
     |> add_bool(
       "--dangerously-bypass-approvals-and-sandbox",
@@ -285,9 +304,18 @@ defmodule CodexWrapper.Exec do
   defp format_sandbox(:workspace_write), do: "workspace-write"
   defp format_sandbox(:danger_full_access), do: "danger-full-access"
 
-  defp format_approval_policy(nil), do: nil
+  # `--ask-for-approval` was removed from `codex exec` in 0.14x. The
+  # `approval_policy` config key is the supported equivalent, so the
+  # builder option is folded into the `-c` overrides rather than dropped.
+  # User-supplied overrides come first, so an explicit
+  # `config("approval_policy=...")` still wins on a last-wins CLI.
+  defp config_overrides(%__MODULE__{approval_policy: nil} = e), do: e.config_overrides
+
+  defp config_overrides(%__MODULE__{} = e) do
+    e.config_overrides ++ [~s(approval_policy="#{format_approval_policy(e.approval_policy)}")]
+  end
+
   defp format_approval_policy(:untrusted), do: "untrusted"
-  defp format_approval_policy(:on_failure), do: "on-failure"
   defp format_approval_policy(:on_request), do: "on-request"
   defp format_approval_policy(:never), do: "never"
 

--- a/lib/codex_wrapper/session.ex
+++ b/lib/codex_wrapper/session.ex
@@ -49,7 +49,7 @@ defmodule CodexWrapper.Session do
 
     * `:model` - Model name
     * `:sandbox` - Sandbox mode
-    * `:approval_policy` - Approval policy
+    * `:approval_policy` - Approval policy (`:untrusted`, `:on_request`, `:never`)
     * `:full_auto` - Enable full-auto (boolean)
     * `:dangerously_bypass_approvals_and_sandbox` - Bypass all (boolean)
     * `:skip_git_repo_check` - Skip git check (boolean)

--- a/test/codex_wrapper/exec_test.exs
+++ b/test/codex_wrapper/exec_test.exs
@@ -47,6 +47,12 @@ defmodule CodexWrapper.ExecTest do
       assert exec.approval_policy == :on_request
     end
 
+    test "approval_policy/2 rejects the removed :on_failure policy" do
+      assert_raise ArgumentError, ~r/no longer a valid approval policy/, fn ->
+        Exec.new("p") |> Exec.approval_policy(:on_failure)
+      end
+    end
+
     test "full_auto/1" do
       exec = Exec.new("p") |> Exec.full_auto()
       assert exec.full_auto == true
@@ -137,12 +143,12 @@ defmodule CodexWrapper.ExecTest do
 
       assert args == [
                "exec",
+               "-c",
+               ~s(approval_policy="on-request"),
                "--model",
                "gpt-5",
                "--sandbox",
                "workspace-write",
-               "--ask-for-approval",
-               "on-request",
                "--skip-git-repo-check",
                "--ephemeral",
                "--json",
@@ -204,14 +210,53 @@ defmodule CodexWrapper.ExecTest do
       assert Enum.at(args, idx + 1) == "danger-full-access"
     end
 
-    test "approval policies" do
-      args = Exec.new("p") |> Exec.approval_policy(:untrusted) |> Exec.args()
-      idx = Enum.find_index(args, &(&1 == "--ask-for-approval"))
-      assert Enum.at(args, idx + 1) == "untrusted"
+    test "approval policies emit the approval_policy config key" do
+      for {policy, value} <- [
+            {:untrusted, "untrusted"},
+            {:on_request, "on-request"},
+            {:never, "never"}
+          ] do
+        args = Exec.new("p") |> Exec.approval_policy(policy) |> Exec.args()
+        idx = Enum.find_index(args, &(&1 == "-c"))
+        assert Enum.at(args, idx + 1) == ~s(approval_policy="#{value}")
+      end
+    end
 
+    test "the removed --ask-for-approval flag is never emitted" do
       args = Exec.new("p") |> Exec.approval_policy(:never) |> Exec.args()
-      idx = Enum.find_index(args, &(&1 == "--ask-for-approval"))
-      assert Enum.at(args, idx + 1) == "never"
+      refute "--ask-for-approval" in args
+    end
+
+    test "no approval_policy override when unset" do
+      args = Exec.new("p") |> Exec.args()
+      refute "-c" in args
+      refute Enum.any?(args, &String.starts_with?(&1, "approval_policy="))
+    end
+
+    test "user config overrides precede the approval_policy override" do
+      args =
+        Exec.new("p")
+        |> Exec.config("model_reasoning_effort=\"high\"")
+        |> Exec.approval_policy(:never)
+        |> Exec.args()
+
+      assert args == [
+               "exec",
+               "-c",
+               ~s(model_reasoning_effort="high"),
+               "-c",
+               ~s(approval_policy="never"),
+               "p"
+             ]
+    end
+
+    test "an explicit approval_policy config override is left alone" do
+      args =
+        Exec.new("p")
+        |> Exec.config(~s(approval_policy="untrusted"))
+        |> Exec.args()
+
+      assert args == ["exec", "-c", ~s(approval_policy="untrusted"), "p"]
     end
 
     test "prompt is always last" do


### PR DESCRIPTION
Closes #53. Phase 1 of the Codex CLI 0.145.0 compatibility work tracked in #52.

## Problem

codex-cli 0.14x removed `--ask-for-approval` from `codex exec`. Passing it is a hard error, so any caller setting `:approval_policy` failed outright.

## Why redirect rather than remove

The capability is not gone upstream, only the flag. Verified against an authenticated codex-cli 0.145.0:

```
$ codex exec --strict-config --ephemeral \
    -c 'approval_policy="never"' \
    'Reply exactly CONFIG_KEYS_OK.'

approval: never
...
CONFIG_KEYS_OK
```

So `approval_policy/2` stays and is redirected to `-c approval_policy="<value>"`. Callers keep the same builder and the same atoms; only the emitted argument changes.

## Changes

- `Exec.args/1` emits `-c approval_policy="<value>"` instead of `--ask-for-approval <value>`
- The override is **appended after** any user-supplied `config/2` overrides, so an explicit `config("approval_policy=...")` still wins on a last-wins CLI. There is a test pinning both orderings.
- `:on_failure` is dropped: the CLI now accepts only `untrusted`, `on-request`, `never`. Passing it raises an `ArgumentError` naming the valid policies rather than silently emitting a value the CLI rejects.
- Docs updated in `Exec.approval_policy/2`, `CodexWrapper` exec opts, `Session` opts, and the README Exec builder example (which used the now-invalid `:on_failure`).

The `CodexWrapper.exec/2` and `Session` keyword passthroughs delegate to `Exec.approval_policy/2`, so they pick this up unchanged -- including the `:on_failure` rejection.

## Scope notes

`ExecResume` and `Review` never carried this option; they only have the separate and still-valid `--dangerously-bypass-approvals-and-sandbox` boolean. `Commands.Fork` has its own copy, deliberately left alone here because #68 removes that module -- doing it in both places would just be a conflict.

## Breaking

Targets v0.5.0 alongside the rest of Phase 1.

```elixir
# before
Exec.approval_policy(e, :on_failure)   # emitted --ask-for-approval on-failure

# after
Exec.approval_policy(e, :never)        # emits -c approval_policy="never"
                                       # :on_failure now raises
```

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` (234 passed)
- [x] `mix dialyzer` (0 errors)
- [x] `mix docs`

New arg-list tests cover each of the three valid policies, that `--ask-for-approval` is never emitted, that no `-c` appears when the policy is unset, the ordering against user config overrides, that an explicit `approval_policy` override is left untouched, and the `:on_failure` raise.

`mix credo --strict` was not run locally: credo 1.7.17 crashes on Elixir 1.20.2 sigil tokens in a pre-existing test file. Local Elixir is 1.20.2; CI pins 1.19, where credo runs.
