### PR TITLE
ci: add a scheduled Codex CLI contract check

### DIFF
--- a/.github/workflows/cli-contract.yml
+++ b/.github/workflows/cli-contract.yml
@@ -1,0 +1,90 @@
+name: CLI contract
+
+# The wrapper drifted silently once: Codex went 0.119 to 0.145 in roughly
+# three months and removed three flags along the way, with nothing in CI
+# noticing (see #52, #64). This job watches for that.
+#
+# Deliberately NOT run on pull_request: a new upstream release breaking
+# the check is information, not a reason to block unrelated work.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  contract:
+    name: Flags vs latest codex CLI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.19"
+          otp-version: "27"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install latest codex CLI
+        run: npm install -g @openai/codex
+
+      - name: Record CLI version
+        run: |
+          echo "### codex CLI" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          codex --version >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Check emitted flags against the CLI
+        id: contract
+        run: |
+          set +e
+          mix codex.contract 2>&1 | tee contract.log
+          echo "status=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Append result to summary
+        if: always()
+        run: |
+          echo "### Contract check" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat contract.log >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      # Surface drift where someone will see it. A red mark on a cron run
+      # is easy to miss; an issue is not.
+      - name: Open or update the drift issue
+        if: steps.contract.outputs.status != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(codex --version)
+          title="CLI drift detected against ${version}"
+          body=$(printf '`mix codex.contract` found flags this wrapper emits that the installed codex CLI no longer accepts.\n\nCLI version: `%s`\nRun: %s/%s/actions/runs/%s\n\n```\n%s\n```\n' \
+            "$version" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID" "$(cat contract.log)")
+
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --label cli-drift --state open --limit 1 --json number --jq '.[0].number')
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh label create cli-drift --repo "$GITHUB_REPOSITORY" \
+              --description "Wrapper emits flags the codex CLI no longer accepts" \
+              --color d73a4a 2>/dev/null || true
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "$title" --label cli-drift --body "$body"
+          fi
+
+      - name: Fail the run when drift was found
+        if: steps.contract.outputs.status != '0'
+        run: exit 1

--- a/lib/mix/tasks/codex.contract.ex
+++ b/lib/mix/tasks/codex.contract.ex
@@ -1,0 +1,186 @@
+defmodule Mix.Tasks.Codex.Contract do
+  @shortdoc "Check the flags this wrapper emits against the installed codex CLI"
+
+  @moduledoc """
+  Compare every flag the builders emit against the installed `codex` CLI.
+
+  The wrapper drifted silently once already: Codex went 0.119 to 0.145 in
+  roughly three months, removing `--ask-for-approval`, `--search` and the
+  `sandbox <platform>` subcommand along the way, and nothing in CI
+  noticed (see #52, #64).
+
+  This task builds a maximal command from each builder, collects the
+  flags it emits, and checks each one against `codex <subcommand>
+  --help`. A flag the CLI no longer lists is reported as drift.
+
+      mix codex.contract
+
+  Exits non-zero when drift is found, so CI can act on it.
+
+  ## Config-key redirects
+
+  Some options are emitted as `-c key=value` config overrides rather
+  than named flags -- `approval_policy` and `web_search` both moved that
+  way when their flags were removed. Config keys never appear in
+  `--help`, so they are probed separately by running the subcommand with
+  `--strict-config` and the override, which rejects unknown keys.
+
+  ## What this does not check
+
+  Flag *semantics*, value sets (an accepted flag whose allowed values
+  changed is invisible here), and anything requiring authentication.
+  It answers one question -- does the CLI still accept the flags we
+  emit -- which is the failure mode that actually bit us.
+  """
+
+  use Mix.Task
+
+  alias CodexWrapper.{Exec, ExecResume, Review}
+
+  @requirements ["app.start"]
+
+  # Each entry: {label, argv the builder produces}. Built maximally so
+  # every option this wrapper can emit shows up in the arg list.
+  defp specs do
+    [
+      {"exec", Exec.args(maximal_exec())},
+      {"exec resume", ExecResume.args(maximal_exec_resume())},
+      {"exec review", Review.args(maximal_review())}
+    ]
+  end
+
+  defp maximal_exec do
+    Exec.new("prompt")
+    |> Exec.model("gpt-5")
+    |> Exec.sandbox(:workspace_write)
+    |> Exec.approval_policy(:never)
+    |> Exec.cd("/tmp")
+    |> Exec.skip_git_repo_check()
+    |> Exec.add_dir("/tmp")
+    |> Exec.search()
+    |> Exec.ephemeral()
+    |> Exec.output_schema("/tmp/schema.json")
+    |> Exec.json()
+    |> Exec.output_last_message("/tmp/last.txt")
+    |> Exec.image("/tmp/a.png")
+    |> Exec.enable("some-feature")
+    |> Exec.disable("other-feature")
+  end
+
+  defp maximal_exec_resume do
+    ExecResume.new()
+    |> ExecResume.session_id("abc-123")
+    |> ExecResume.prompt("continue")
+    |> ExecResume.model("gpt-5")
+    |> ExecResume.last()
+    |> ExecResume.skip_git_repo_check()
+    |> ExecResume.ephemeral()
+    |> ExecResume.json()
+    |> ExecResume.output_last_message("/tmp/last.txt")
+  end
+
+  defp maximal_review do
+    Review.new()
+    |> Review.prompt("look at this")
+    |> Review.base("main")
+    |> Review.model("gpt-5")
+    |> Review.title("a title")
+    |> Review.skip_git_repo_check()
+    |> Review.ephemeral()
+    |> Review.json()
+    |> Review.output_last_message("/tmp/last.txt")
+  end
+
+  @impl Mix.Task
+  def run(_argv) do
+    binary = System.find_executable("codex") || Mix.raise("codex not found on PATH")
+
+    Mix.shell().info("codex: #{binary}")
+    Mix.shell().info(version(binary))
+    Mix.shell().info("")
+
+    findings = Enum.flat_map(specs(), &check(binary, &1))
+
+    if findings == [] do
+      Mix.shell().info("No drift: every emitted flag is still accepted.")
+    else
+      Mix.shell().error("Drift found:\n")
+      Enum.each(findings, &Mix.shell().error("  " <> &1))
+
+      Mix.shell().error("""
+
+      Each line is a flag or config key this wrapper emits that the
+      installed codex CLI no longer accepts. Fix the builder, or redirect
+      the option to a config key the way #53 and #54 did.
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+
+  defp version(binary) do
+    case System.cmd(binary, ["--version"], stderr_to_stdout: true) do
+      {out, 0} -> String.trim(out)
+      {out, _} -> "version unknown: #{String.trim(out)}"
+    end
+  end
+
+  defp check(binary, {label, argv}) do
+    subcommand = String.split(label)
+    {flags, config_keys} = split_emitted(argv)
+    accepted = help_flags(binary, subcommand)
+
+    missing_flags =
+      flags
+      |> Enum.reject(&MapSet.member?(accepted, &1))
+      |> Enum.map(&"#{label}: #{&1} is not in `codex #{label} --help`")
+
+    missing_keys =
+      config_keys
+      |> Enum.reject(&config_key_accepted?(binary, subcommand, &1))
+      |> Enum.map(&"#{label}: -c #{&1} was rejected under --strict-config")
+
+    missing_flags ++ missing_keys
+  end
+
+  # Walk the argv, separating named flags from the `-c key=value` pairs.
+  # A flag's *value* must not be mistaken for a flag, so `-c` and any
+  # option taking a value consume the next element.
+  defp split_emitted(argv), do: split_emitted(argv, [], [])
+
+  defp split_emitted([], flags, keys), do: {Enum.uniq(flags), Enum.uniq(keys)}
+
+  defp split_emitted(["-c", kv | rest], flags, keys),
+    do: split_emitted(rest, flags, [kv | keys])
+
+  defp split_emitted(["--" | _rest], flags, keys), do: split_emitted([], flags, keys)
+
+  defp split_emitted([arg | rest], flags, keys) do
+    if String.starts_with?(arg, "-") do
+      split_emitted(rest, [arg | flags], keys)
+    else
+      split_emitted(rest, flags, keys)
+    end
+  end
+
+  # Every `--flag` / `-f` token the subcommand's help text mentions.
+  defp help_flags(binary, subcommand) do
+    {out, _} = System.cmd(binary, subcommand ++ ["--help"], stderr_to_stdout: true)
+
+    ~r/(?<![\w-])(--?[a-zA-Z][\w-]*)/
+    |> Regex.scan(out)
+    |> Enum.map(fn [_, flag] -> flag end)
+    |> MapSet.new()
+  end
+
+  # `--strict-config` rejects unknown config keys. `--help` short-circuits
+  # before the run, so this costs nothing and needs no auth.
+  defp config_key_accepted?(binary, subcommand, kv) do
+    args = subcommand ++ ["--strict-config", "-c", kv, "--help"]
+
+    case System.cmd(binary, args, stderr_to_stdout: true) do
+      {_out, 0} -> true
+      _ -> false
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,11 @@ defmodule CodexWrapperEx.MixProject do
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      dialyzer: [plt_file: {:no_warn, "_build/dev/dialyxir_#{System.otp_release()}.plt"}],
+      dialyzer: [
+        plt_file: {:no_warn, "_build/dev/dialyxir_#{System.otp_release()}.plt"},
+        # `mix codex.contract` is a Mix task, so Mix must be in the PLT.
+        plt_add_apps: [:mix]
+      ],
       docs: docs(),
       package: package(),
       name: "CodexWrapper",


### PR DESCRIPTION
Closes #64. Phase 3 of #52 -- the process fix so this drift does not recur.

## Why

Every Phase 1 fix (#53, #54, #55, #56, #57) addressed a problem a machine could have reported the week it appeared. Codex went 0.119 to 0.145 in roughly three months and removed three flags and restructured two subcommands; nothing in CI noticed, and the survey that caught it was manual.

## What

**`mix codex.contract`** builds a maximal command from each builder (`exec`, `exec resume`, `exec review`), collects every flag it emits, and checks each against `codex <sub> --help`. Exits non-zero on drift.

Config-key redirects are handled separately, as #64 asked: `approval_policy` and `web_search` are emitted as `-c key=value` and never appear in help output, so they are probed by running the subcommand with `--strict-config`, which rejects unknown keys. Neither path needs auth -- `--help` short-circuits before the run.

**`.github/workflows/cli-contract.yml`** runs it weekly plus `workflow_dispatch`, installs the latest `@openai/codex`, records the CLI version and the check output in the job summary, and on failure opens (or comments on) a `cli-drift` issue.

Deliberately **not** on `pull_request`, and it does not gate merges: a new upstream release breaking the check is information, not a reason to block unrelated work. The issue is the delivery mechanism because a red mark on a cron run is easy to miss.

## It actually works

Run against a real codex-cli 0.145.0, on this branch (which is off main, so the Phase 1 fixes are not in it), the task independently rediscovers exactly what the manual survey found:

```
codex: /Users/…/.local/bin/codex
codex-cli 0.145.0

Drift found:

  exec: --search is not in `codex exec --help`
  exec: --ask-for-approval is not in `codex exec --help`
```

That is the intended behaviour, not a bug in the check: on main those flags are still emitted. Once #69 and #70 land the check goes quiet, and it will speak up again the next time upstream moves.

## Limits, stated plainly

It checks flag *acceptance*, not semantics. An accepted flag whose allowed values changed is invisible to it -- `:on_failure` disappearing from the approval policy set would not have been caught. It also cannot see the `Commands.*` modules that do not go through a builder with an `args/1`. Both are worth extending later; this covers the failure mode that actually bit us.

## Note

Adds `plt_add_apps: [:mix]` to the dialyzer config so it can see the `Mix.Task` behaviour. Without it dialyzer reports `Mix.shell/0` and `Mix.raise/1` as unknown functions.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` (229 passed)
- [x] `mix dialyzer` (0 errors, with `:mix` in the PLT)
- [x] `mix docs`
- [x] `mix codex.contract` run against a live codex-cli 0.145.0

The workflow itself cannot be verified until it runs on a schedule or via `workflow_dispatch` on main. Worth a manual dispatch after merge.
