### PR TITLE
feat: add output_schema to the Review builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ Review.new()
 |> Review.execute(config)
 ```
 
+`output_schema/2` points `codex exec review` at a JSON Schema file via
+`--output-schema`, the same way `Exec.output_schema/2` does, so a review
+can return structured output:
+
+```elixir
+Review.new()
+|> Review.uncommitted()
+|> Review.output_schema("/path/to/schema.json")
+|> Review.execute(config)
+```
+
 `full_auto/1` is still available on `Exec`, `ExecResume` and `Review`,
 but it is deprecated upstream: it now emits `--sandbox workspace-write`
 rather than the deprecated `--full-auto` flag. An explicit `sandbox/2`

--- a/lib/codex_wrapper.ex
+++ b/lib/codex_wrapper.ex
@@ -182,6 +182,7 @@ defmodule CodexWrapper do
     * `:dangerously_bypass_approvals_and_sandbox` - Bypass all (boolean)
     * `:skip_git_repo_check` - Skip git check (boolean)
     * `:ephemeral` - Ephemeral mode (boolean)
+    * `:output_schema` - Output schema path
     * `:json` - JSON output (boolean)
     * `:output_last_message` - Output last message path
 
@@ -254,6 +255,9 @@ defmodule CodexWrapper do
 
       {:ephemeral, false}, r ->
         r
+
+      {:output_schema, v}, r ->
+        Review.output_schema(r, v)
 
       {:json, true}, r ->
         Review.json(r)

--- a/lib/codex_wrapper/review.ex
+++ b/lib/codex_wrapper/review.ex
@@ -24,6 +24,12 @@ defmodule CodexWrapper.Review do
       CodexWrapper.Review.new()
       |> CodexWrapper.Review.commit("abc123")
       |> CodexWrapper.Review.execute(config)
+
+      # Ask for structured review output
+      CodexWrapper.Review.new()
+      |> CodexWrapper.Review.uncommitted()
+      |> CodexWrapper.Review.output_schema("/path/to/schema.json")
+      |> CodexWrapper.Review.execute(config)
   """
 
   @behaviour CodexWrapper.Command
@@ -44,6 +50,7 @@ defmodule CodexWrapper.Review do
           dangerously_bypass_approvals_and_sandbox: boolean(),
           skip_git_repo_check: boolean(),
           ephemeral: boolean(),
+          output_schema: String.t() | nil,
           json: boolean(),
           output_last_message: String.t() | nil,
           config_overrides: [String.t()],
@@ -57,6 +64,7 @@ defmodule CodexWrapper.Review do
     :commit,
     :title,
     :model,
+    :output_schema,
     :output_last_message,
     :sandbox,
     uncommitted: false,
@@ -130,6 +138,10 @@ defmodule CodexWrapper.Review do
   @doc "Enable ephemeral mode (no session persistence)."
   @spec ephemeral(t()) :: t()
   def ephemeral(%__MODULE__{} = r), do: %{r | ephemeral: true}
+
+  @doc "Set the output schema path."
+  @spec output_schema(t(), String.t()) :: t()
+  def output_schema(%__MODULE__{} = r, path), do: %{r | output_schema: path}
 
   @doc "Enable JSON output."
   @spec json(t()) :: t()
@@ -248,6 +260,7 @@ defmodule CodexWrapper.Review do
     )
     |> add_bool("--skip-git-repo-check", r.skip_git_repo_check)
     |> add_bool("--ephemeral", r.ephemeral)
+    |> add_opt("--output-schema", r.output_schema)
     |> add_bool("--json", r.json)
     |> add_opt("--output-last-message", r.output_last_message)
     |> add_prompt(r.prompt)

--- a/test/codex_wrapper/review_test.exs
+++ b/test/codex_wrapper/review_test.exs
@@ -17,6 +17,7 @@ defmodule CodexWrapper.ReviewTest do
       assert review.skip_git_repo_check == false
       assert review.ephemeral == false
       assert review.json == false
+      assert review.output_schema == nil
       assert review.output_last_message == nil
       assert review.config_overrides == []
       assert review.enabled_features == []
@@ -78,6 +79,11 @@ defmodule CodexWrapper.ReviewTest do
     test "json/1" do
       review = Review.new() |> Review.json()
       assert review.json == true
+    end
+
+    test "output_schema/2" do
+      review = Review.new() |> Review.output_schema("/tmp/schema.json")
+      assert review.output_schema == "/tmp/schema.json"
     end
 
     test "output_last_message/2" do
@@ -188,6 +194,20 @@ defmodule CodexWrapper.ReviewTest do
       assert "--dangerously-bypass-approvals-and-sandbox" in args
       assert "--skip-git-repo-check" in args
       assert "--ephemeral" in args
+    end
+
+    test "output_schema flag" do
+      args =
+        Review.new()
+        |> Review.output_schema("/tmp/schema.json")
+        |> Review.args()
+
+      idx = Enum.find_index(args, &(&1 == "--output-schema"))
+      assert Enum.at(args, idx + 1) == "/tmp/schema.json"
+    end
+
+    test "output_schema is omitted when unset" do
+      refute "--output-schema" in Review.args(Review.new())
     end
 
     test "title flag" do


### PR DESCRIPTION
Closes #59. Part of the #52 Codex CLI 0.145.0 compatibility survey (Phase 2, additive).

## Problem

`codex exec review` accepts `--output-schema <file>` on 0.145.0. `CodexWrapper.Exec` exposes this, but `CodexWrapper.Review` did not, so structured review output was only reachable through `CodexWrapper.raw/1`.

## Change

- `Review.output_schema/2`, mirroring `Exec.output_schema/2` exactly (same `@doc`, same `@spec` shape, same struct field name).
- `--output-schema <path>` emitted from `Review.args/1` in the same position `Exec.args/1` uses: after `--ephemeral`, before `--json`.
- `:output_schema` keyword passthrough in `CodexWrapper.review/1`, plus the option listed in the `review/1` docs.
- Moduledoc usage example and README "Review builder" section updated.

## Tests

Three additions to `test/codex_wrapper/review_test.exs`:

- `output_schema/2` sets the struct field
- `--output-schema` is followed by the path in the arg list
- `--output-schema` is absent when unset
- the `new/0` defaults test now asserts `output_schema == nil`

Full suite: 248 passed.

## Notes

- No test covers the `CodexWrapper.review/1` keyword passthrough. `build_review/1` is private and only reachable by invoking the real binary, so none of its sibling options (`:output_last_message`, `:ephemeral`, ...) are tested either. Left consistent with the existing shape rather than adding a new harness for one option.
- Local gates green: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix test`, `mix dialyzer`, `mix docs`. `mix credo --strict` was not run locally; credo 1.7.17 crashes on Elixir 1.20.2 sigil tokens in this repo. CI runs it on the pinned 1.19/OTP 27 toolchain.
