### PR TITLE
feat: support codex login --with-access-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ alias CodexWrapper.Commands.Auth
 
 {:ok, _} = Auth.login(config)
 {:ok, _} = Auth.login(config, with_api_key: true)
+{:ok, _} = Auth.login(config, with_access_token: true)
 {:ok, _} = Auth.status(config)
 {:ok, _} = Auth.logout(config)
 ```

--- a/lib/codex_wrapper/commands/auth.ex
+++ b/lib/codex_wrapper/commands/auth.ex
@@ -13,12 +13,14 @@ defmodule CodexWrapper.Commands.Auth do
   ## Options
 
     * `:with_api_key` - Use API key authentication (boolean)
+    * `:with_access_token` - Use access token authentication (boolean)
     * `:device_auth` - Use device authorization flow (boolean)
   """
   @spec login(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
   def login(%Config{} = config, opts \\ []) do
     args = Config.base_args(config) ++ ["login"]
     args = if opts[:with_api_key], do: args ++ ["--with-api-key"], else: args
+    args = if opts[:with_access_token], do: args ++ ["--with-access-token"], else: args
     args = if opts[:device_auth], do: args ++ ["--device-auth"], else: args
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do

--- a/test/codex_wrapper/commands/auth_test.exs
+++ b/test/codex_wrapper/commands/auth_test.exs
@@ -16,6 +16,12 @@ defmodule CodexWrapper.Commands.AuthTest do
       assert output =~ "--with-api-key"
     end
 
+    test "builds args with with_access_token" do
+      config = Config.new(binary: "echo")
+      assert {:ok, output} = Auth.login(config, with_access_token: true)
+      assert output =~ "--with-access-token"
+    end
+
     test "builds args with device_auth" do
       config = Config.new(binary: "echo")
       assert {:ok, output} = Auth.login(config, device_auth: true)


### PR DESCRIPTION
Closes #60. Part of #52 (Codex CLI 0.145.0 compatibility).

## Change

`codex login` on 0.145.0 accepts `--with-access-token` alongside the already-wrapped `--with-api-key` and `--device-auth`. This adds a matching `with_access_token: true` option to `CodexWrapper.Commands.Auth.login/2`, built the same way as `:with_api_key`.

```elixir
Auth.login(config, with_access_token: true)
# => codex login --with-access-token
```

## Scope

- `lib/codex_wrapper/commands/auth.ex`: new option plus a `@doc` entry
- `test/codex_wrapper/commands/auth_test.exs`: arg-list test asserting `--with-access-token`
- `README.md`: Authentication section shows the new call

Additive. No existing behavior changes.

## Checks

Local: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix test` (246 passed), `mix dialyzer` (0 errors), `mix docs`. `mix credo --strict` is left to CI; it crashes locally on Elixir 1.20.2 while CI pins 1.19/OTP 27.
