### PR TITLE
feat: add Commands.Doctor for codex doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,36 @@ Sandbox.new("pytest")
 Codex CLI dropped the platform subcommand and infers the platform from
 the host, so passing an atom now raises with a migration message.
 
+## Diagnostics
+
+`codex doctor` checks the local install, config, auth, and runtime health.
+It works as a preflight before a run:
+
+```elixir
+alias CodexWrapper.Commands.Doctor
+
+{:ok, report} = Doctor.new() |> Doctor.summary() |> Doctor.execute(config)
+```
+
+`execute/2` returns the human-readable report as a string. For the
+machine-readable form, `execute_json/2` forces `--json` and decodes it:
+
+```elixir
+{:ok, report} = Doctor.new() |> Doctor.execute_json(config)
+
+report["overallStatus"]
+#=> "warning"
+
+report["checks"]["auth.credentials"]["status"]
+#=> "ok"
+```
+
+`codex doctor` exits 0 even when checks report warnings or failures, so a
+successful call is not by itself a clean bill of health. Read
+`"overallStatus"` rather than relying on the exit code.
+
+Builders: `json/1`, `summary/1`, `all/1`, `no_color/1`, `ascii/1`.
+
 ## Shell completions
 
 ```elixir
@@ -442,6 +472,7 @@ The streaming paths (`Exec.stream/2` and friends) still use the built-in
 | `CodexWrapper.Commands.Fork` | Session forking |
 | `CodexWrapper.Commands.Apply` | Apply diffs from task IDs |
 | `CodexWrapper.Commands.Completion` | Shell completion script generation |
+| `CodexWrapper.Commands.Doctor` | Install, config, auth, and runtime diagnostics |
 | `CodexWrapper.Commands.Version` | CLI version |
 
 ## License

--- a/lib/codex_wrapper/commands/doctor.ex
+++ b/lib/codex_wrapper/commands/doctor.ex
@@ -1,0 +1,138 @@
+defmodule CodexWrapper.Commands.Doctor do
+  @moduledoc """
+  Doctor command -- diagnose the local Codex install, config, auth, and
+  runtime health.
+
+  Wraps `codex doctor [OPTIONS]`. Useful as a preflight before a run:
+  it reports whether the CLI is installed, whether auth is configured,
+  and whether the configured provider endpoints are reachable.
+
+  ## Usage
+
+      config = CodexWrapper.Config.new()
+
+      {:ok, report} = CodexWrapper.Commands.Doctor.execute(Doctor.new(), config)
+
+  For a machine-readable report, use `execute_json/2`:
+
+      {:ok, report} = CodexWrapper.Commands.Doctor.execute_json(Doctor.new(), config)
+
+      report["overallStatus"]
+      #=> "ok"
+
+  ## Exit status
+
+  `codex doctor` exits 0 even when checks report warnings or failures, so
+  a successful call is not by itself a clean bill of health. Read
+  `"overallStatus"` from the JSON report (`"ok"`, `"warning"`, ...) rather
+  than relying on the exit code.
+  """
+
+  @behaviour CodexWrapper.Command
+
+  alias CodexWrapper.{Command, Config}
+
+  @type t :: %__MODULE__{
+          json: boolean(),
+          summary: boolean(),
+          all: boolean(),
+          no_color: boolean(),
+          ascii: boolean()
+        }
+
+  defstruct json: false,
+            summary: false,
+            all: false,
+            no_color: false,
+            ascii: false
+
+  # --- Constructor ---
+
+  @doc """
+  Create a doctor command with every option unset.
+  """
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  # --- Builder functions ---
+
+  @doc "Emit a redacted machine-readable report (`--json`)."
+  @spec json(t()) :: t()
+  def json(%__MODULE__{} = d), do: %{d | json: true}
+
+  @doc "Show only grouped check rows and the final count summary (`--summary`)."
+  @spec summary(t()) :: t()
+  def summary(%__MODULE__{} = d), do: %{d | summary: true}
+
+  @doc "Expand long lists in detailed human output (`--all`)."
+  @spec all(t()) :: t()
+  def all(%__MODULE__{} = d), do: %{d | all: true}
+
+  @doc "Disable ANSI color in human output (`--no-color`)."
+  @spec no_color(t()) :: t()
+  def no_color(%__MODULE__{} = d), do: %{d | no_color: true}
+
+  @doc "Use ASCII status labels and separators in human output (`--ascii`)."
+  @spec ascii(t()) :: t()
+  def ascii(%__MODULE__{} = d), do: %{d | ascii: true}
+
+  # --- Execution ---
+
+  @doc """
+  Run the diagnostics synchronously, returning the report as a string.
+
+  The human-readable report is a display format, not a stable contract.
+  Use `execute_json/2` when the caller needs to inspect the result.
+  """
+  @spec execute(t(), Config.t()) :: {:ok, String.t()} | {:error, term()}
+  def execute(%__MODULE__{} = doctor, %Config{} = config) do
+    Command.run(__MODULE__, doctor, config)
+  end
+
+  @doc """
+  Run the diagnostics with `--json` and return the decoded report.
+
+  Forces `--json` on the command. The report is a map keyed by
+  `"schemaVersion"`, `"overallStatus"`, `"codexVersion"`, and `"checks"`.
+  """
+  @spec execute_json(t(), Config.t()) :: {:ok, map()} | {:error, term()}
+  def execute_json(%__MODULE__{} = doctor, %Config{} = config) do
+    case execute(%{doctor | json: true}, config) do
+      {:ok, output} ->
+        case Jason.decode(output) do
+          {:ok, report} -> {:ok, report}
+          {:error, reason} -> {:error, {:json_decode, reason}}
+        end
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  # --- Arg building ---
+
+  @doc """
+  Build the argument list for this command.
+  """
+  @spec build_args(t()) :: [String.t()]
+  def build_args(%__MODULE__{} = d), do: args(d)
+
+  @impl true
+  def args(%__MODULE__{} = d) do
+    ["doctor"]
+    |> add_bool("--json", d.json)
+    |> add_bool("--summary", d.summary)
+    |> add_bool("--all", d.all)
+    |> add_bool("--no-color", d.no_color)
+    |> add_bool("--ascii", d.ascii)
+  end
+
+  @impl true
+  def parse_output(stdout, 0), do: {:ok, String.trim(stdout)}
+  def parse_output(stdout, exit_code), do: {:error, {:exit, exit_code, stdout}}
+
+  # --- Arg helpers ---
+
+  defp add_bool(args, _flag, false), do: args
+  defp add_bool(args, flag, true), do: args ++ [flag]
+end

--- a/test/codex_wrapper/commands/doctor_test.exs
+++ b/test/codex_wrapper/commands/doctor_test.exs
@@ -1,0 +1,77 @@
+defmodule CodexWrapper.Commands.DoctorTest do
+  use ExUnit.Case, async: true
+
+  alias CodexWrapper.Commands.Doctor
+
+  describe "new/0" do
+    test "defaults every option to unset" do
+      doctor = Doctor.new()
+      assert doctor.json == false
+      assert doctor.summary == false
+      assert doctor.all == false
+      assert doctor.no_color == false
+      assert doctor.ascii == false
+    end
+  end
+
+  describe "builder functions" do
+    test "json/1 sets the flag" do
+      assert Doctor.new() |> Doctor.json() |> Map.fetch!(:json) == true
+    end
+
+    test "summary/1 sets the flag" do
+      assert Doctor.new() |> Doctor.summary() |> Map.fetch!(:summary) == true
+    end
+
+    test "all/1 sets the flag" do
+      assert Doctor.new() |> Doctor.all() |> Map.fetch!(:all) == true
+    end
+
+    test "no_color/1 sets the flag" do
+      assert Doctor.new() |> Doctor.no_color() |> Map.fetch!(:no_color) == true
+    end
+
+    test "ascii/1 sets the flag" do
+      assert Doctor.new() |> Doctor.ascii() |> Map.fetch!(:ascii) == true
+    end
+  end
+
+  describe "args/1" do
+    test "emits just the subcommand when nothing is set" do
+      assert Doctor.args(Doctor.new()) == ["doctor"]
+    end
+
+    test "emits each flag when set" do
+      args =
+        Doctor.new()
+        |> Doctor.json()
+        |> Doctor.summary()
+        |> Doctor.all()
+        |> Doctor.no_color()
+        |> Doctor.ascii()
+        |> Doctor.args()
+
+      assert args == ["doctor", "--json", "--summary", "--all", "--no-color", "--ascii"]
+    end
+
+    test "omits unset flags" do
+      args = Doctor.new() |> Doctor.json() |> Doctor.args()
+      assert args == ["doctor", "--json"]
+    end
+
+    test "build_args/1 matches args/1" do
+      doctor = Doctor.new() |> Doctor.summary()
+      assert Doctor.build_args(doctor) == Doctor.args(doctor)
+    end
+  end
+
+  describe "parse_output/2" do
+    test "returns the trimmed output on exit 0" do
+      assert Doctor.parse_output("  15 ok · 0 fail\n", 0) == {:ok, "15 ok · 0 fail"}
+    end
+
+    test "returns an error tuple on a nonzero exit" do
+      assert Doctor.parse_output("boom", 1) == {:error, {:exit, 1, "boom"}}
+    end
+  end
+end


### PR DESCRIPTION
Closes #63. Part of #52 (Codex CLI 0.145.0 compatibility), Phase 2 additive set.

## Change

codex-cli 0.145.0 added `codex doctor`, which diagnoses the local install, config, auth, and runtime health. The wrapper had no way to reach it short of `CodexWrapper.raw/1`.

- `CodexWrapper.Commands.Doctor` with `new/0` and one builder per flag the CLI accepts: `json/1`, `summary/1`, `all/1`, `no_color/1`, `ascii/1`
- `execute/2` routed through `Command.run/3`, returning the human-readable report as a trimmed string
- `execute_json/2` forces `--json` and decodes the report with `Jason`, mirroring the `Commands.Mcp` json-passthrough shape
- README: a "Diagnostics" section plus a `Commands.Doctor` row in the Modules table

Purely additive.

## Output parsing decision

The issue asked to decide raw-string vs structured after checking whether `--json` is supported. Verified against the real binary (codex-cli 0.145.0):

```
$ codex doctor --help
      --json      Emit a redacted machine-readable report
      --summary   Only show grouped check rows and the final count summary
      --all       Expand long lists in detailed human output
      --no-color  Disable ANSI color in human output
      --ascii     Use ASCII status labels and separators in human output
```

`--json` emits a versioned document (`schemaVersion: 1`, `overallStatus`, `codexVersion`, `checks` keyed by check id, each with `status`/`summary`/`details`/`remediation`/`durationMs`). Stable enough to decode, so both paths ship: `execute/2` returns the human report raw, `execute_json/2` returns the decoded map. No wrapper-side struct over the report; the CLI's own schema version is the contract.

## Exit status

`codex doctor` exits **0** even when checks report warnings or failures. Confirmed locally: a run reporting `2 warn ... degraded` still exited 0. So a successful call is not by itself a clean bill of health, and the moduledoc and README both point callers at `"overallStatus"` instead of the exit code. `parse_output/2` treats a nonzero exit as a hard failure (`{:error, {:exit, code, stdout}}`), which then means the CLI itself failed rather than a check.

## Tests

Twelve tests in `test/codex_wrapper/commands/doctor_test.exs`: a `new/0` defaults assertion, a builder test per flag, arg-list tests (bare subcommand, all flags set with their order pinned, unset flags omitted, `build_args/1` agreeing with `args/1`), and `parse_output/2` on both the zero and nonzero exit paths.

No test covers `execute_json/2` end to end; it needs the real binary, consistent with how the other execute paths in this repo are left untested.

## Gates

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` (257 passed)
- [x] `mix dialyzer` (0 errors)
- [x] `mix docs`
- [ ] `mix credo --strict` -- cannot run locally (credo 1.7.17 crashes with a `FunctionClauseError` in `Credo.Code.Token.position/1` on Elixir 1.20.2 sigil tokens in `test/codex_wrapper/json_line_event_test.exs`, unrelated to this change); CI's pinned Elixir 1.19 / OTP 27 covers it

## Unrelated observation

The README Modules table still lists `CodexWrapper.Commands.Fork`, which #57 deleted (`7d0e1ef`). The prose at README.md:180 already explains the removal, so the table row is a leftover. Not touched here to keep the diff to #63.
