### PR TITLE
feat: add mcp login/logout and OAuth options to Commands.Mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,11 +248,29 @@ config = CodexWrapper.Config.new()
   bearer_token_env_var: "MY_TOKEN"
 )
 
+# Add a server that authenticates over OAuth
+{:ok, _} = Mcp.add(config, "oauth-server", :http,
+  url: "https://example.com/mcp",
+  oauth_client_id: "codex-cli",
+  oauth_resource: "https://example.com"
+)
+
 # Get server details
 {:ok, info} = Mcp.get(config, "my-server", json: true)
 
 # Remove a server
 {:ok, _} = Mcp.remove(config, "my-server")
+```
+
+### MCP OAuth
+
+`login/3` runs the OAuth flow for a configured server and `logout/2` clears
+its credentials.
+
+```elixir
+{:ok, _} = Mcp.login(config, "oauth-server")
+{:ok, _} = Mcp.login(config, "oauth-server", scopes: ["read", "write"])
+{:ok, _} = Mcp.logout(config, "oauth-server")
 ```
 
 ## Running Codex as an MCP server

--- a/lib/codex_wrapper/commands/mcp.ex
+++ b/lib/codex_wrapper/commands/mcp.ex
@@ -2,7 +2,7 @@ defmodule CodexWrapper.Commands.Mcp do
   @moduledoc """
   MCP (Model Context Protocol) server management commands.
 
-  Wraps `codex mcp list|get|add|remove`.
+  Wraps `codex mcp list|get|add|remove|login|logout`.
   """
 
   alias CodexWrapper.Config
@@ -53,6 +53,23 @@ defmodule CodexWrapper.Commands.Mcp do
   ## HTTP transport
 
       Mcp.add(config, "my-server", :http, url: "http://localhost:8080")
+
+  ## OAuth
+
+  `:oauth_client_id` and `:oauth_resource` are accepted on both transports;
+  the CLI does not restrict them to one. They configure the OAuth exchange
+  that `login/3` later performs.
+
+      Mcp.add(config, "remote", :http,
+        url: "https://example.com/mcp",
+        oauth_client_id: "codex-cli",
+        oauth_resource: "https://example.com"
+      )
+
+  ## Options
+
+    * `:oauth_client_id` - OAuth client identifier for this server
+    * `:oauth_resource` - OAuth resource parameter to include during login
   """
   @spec add(Config.t(), String.t(), :stdio | :http, keyword()) ::
           {:ok, String.t()} | {:error, term()}
@@ -62,7 +79,7 @@ defmodule CodexWrapper.Commands.Mcp do
     env = Keyword.get(opts, :env, %{})
 
     args = Config.base_args(config) ++ ["mcp", "add", name]
-    args = args ++ env_args(env)
+    args = args ++ env_args(env) ++ oauth_args(opts)
     args = args ++ ["--", command] ++ command_args
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
@@ -82,6 +99,8 @@ defmodule CodexWrapper.Commands.Mcp do
         var -> args ++ ["--bearer-token-env-var", var]
       end
 
+    args = args ++ oauth_args(opts)
+
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, {:exit, code, output}}
@@ -94,6 +113,40 @@ defmodule CodexWrapper.Commands.Mcp do
   @spec remove(Config.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
   def remove(%Config{} = config, name) do
     args = Config.base_args(config) ++ ["mcp", "remove", name]
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc """
+  Authenticate with an MCP server over OAuth.
+
+      Mcp.login(config, "remote")
+      Mcp.login(config, "remote", scopes: ["read", "write"])
+
+  ## Options
+
+    * `:scopes` - OAuth scopes to request, as a list or an already-joined
+      comma-separated string
+  """
+  @spec login(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def login(%Config{} = config, name, opts \\ []) do
+    args = Config.base_args(config) ++ ["mcp", "login", name] ++ scopes_args(opts[:scopes])
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc """
+  Deauthenticate an MCP server.
+  """
+  @spec logout(Config.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def logout(%Config{} = config, name) do
+    args = Config.base_args(config) ++ ["mcp", "logout", name]
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
@@ -115,4 +168,18 @@ defmodule CodexWrapper.Commands.Mcp do
   defp env_args(env) do
     Enum.flat_map(env, fn {k, v} -> ["--env", "#{k}=#{v}"] end)
   end
+
+  defp oauth_args(opts) do
+    [{:oauth_client_id, "--oauth-client-id"}, {:oauth_resource, "--oauth-resource"}]
+    |> Enum.flat_map(fn {key, flag} ->
+      case Keyword.get(opts, key) do
+        nil -> []
+        value -> [flag, value]
+      end
+    end)
+  end
+
+  defp scopes_args(nil), do: []
+  defp scopes_args(scopes) when is_list(scopes), do: ["--scopes", Enum.join(scopes, ",")]
+  defp scopes_args(scopes) when is_binary(scopes), do: ["--scopes", scopes]
 end

--- a/test/codex_wrapper/commands/mcp_test.exs
+++ b/test/codex_wrapper/commands/mcp_test.exs
@@ -95,6 +95,42 @@ defmodule CodexWrapper.Commands.McpTest do
     end
   end
 
+  describe "add/4 oauth options" do
+    test "builds http add args with oauth client id and resource" do
+      config = Config.new(binary: "echo")
+
+      assert {:ok, output} =
+               Mcp.add(config, "srv", :http,
+                 url: "https://example.com/mcp",
+                 oauth_client_id: "codex-cli",
+                 oauth_resource: "https://example.com"
+               )
+
+      assert output =~ "--oauth-client-id codex-cli"
+      assert output =~ "--oauth-resource https://example.com"
+    end
+
+    test "builds stdio add args with oauth options before the command separator" do
+      config = Config.new(binary: "echo")
+
+      assert {:ok, output} =
+               Mcp.add(config, "srv", :stdio,
+                 command: "npx",
+                 oauth_client_id: "codex-cli"
+               )
+
+      assert output =~ "--oauth-client-id codex-cli -- npx"
+    end
+
+    test "omits oauth flags when unset" do
+      config = Config.new(binary: "echo")
+
+      assert {:ok, output} = Mcp.add(config, "srv", :http, url: "https://example.com/mcp")
+      refute output =~ "--oauth-client-id"
+      refute output =~ "--oauth-resource"
+    end
+  end
+
   describe "remove/2" do
     test "builds remove args" do
       config = Config.new(binary: "echo")
@@ -102,6 +138,35 @@ defmodule CodexWrapper.Commands.McpTest do
       assert output =~ "mcp"
       assert output =~ "remove"
       assert output =~ "my-server"
+    end
+  end
+
+  describe "login/3" do
+    test "builds login args" do
+      config = Config.new(binary: "echo")
+      assert {:ok, output} = Mcp.login(config, "my-server")
+      assert output =~ "mcp login my-server"
+      refute output =~ "--scopes"
+    end
+
+    test "joins a scope list into one comma-separated value" do
+      config = Config.new(binary: "echo")
+      assert {:ok, output} = Mcp.login(config, "my-server", scopes: ["read", "write"])
+      assert output =~ "mcp login my-server --scopes read,write"
+    end
+
+    test "passes a scope string through unchanged" do
+      config = Config.new(binary: "echo")
+      assert {:ok, output} = Mcp.login(config, "my-server", scopes: "read,write")
+      assert output =~ "--scopes read,write"
+    end
+  end
+
+  describe "logout/2" do
+    test "builds logout args" do
+      config = Config.new(binary: "echo")
+      assert {:ok, output} = Mcp.logout(config, "my-server")
+      assert output =~ "mcp logout my-server"
     end
   end
 end


### PR DESCRIPTION
Closes #61. Part of #52 (Codex CLI 0.145.0 compatibility), Phase 2 additive set.

## Change

codex-cli 0.145.0 added MCP OAuth support the wrapper did not cover. Verified against the real binary (codex-cli 0.145.0):

```
$ codex mcp login --help
Usage: codex mcp login [OPTIONS] <NAME>
      --scopes <SCOPE,SCOPE>  Comma-separated list of OAuth scopes to request

$ codex mcp add --help
      --oauth-client-id <CLIENT_ID>  Optional OAuth client identifier to use for this MCP server
      --oauth-resource <RESOURCE>    Optional OAuth resource parameter to include during MCP login
```

- `Mcp.login/3` emitting `mcp login <name>`. `:scopes` accepts a list (joined on commas) or an already-joined string.
- `Mcp.logout/2` emitting `mcp logout <name>`.
- `:oauth_client_id` / `:oauth_resource` on `Mcp.add/4`.
- README: an OAuth `add` example plus an "MCP OAuth" subsection.

Additive. No existing arg list changes when the new options are unset.

## Two decisions worth flagging

**`--scopes` on login.** The issue named only `login` and `logout`, but `--scopes` is the one option `codex mcp login` takes, so leaving it out would have meant a second pass. Included as `:scopes`.

**OAuth options on both transports.** `--bearer-token-env-var` is documented "Only valid with streamable HTTP servers", and the wrapper restricts it to the `:http` clause accordingly. `--oauth-client-id` and `--oauth-resource` carry no such note in `--help`, so both clauses accept them. On the stdio clause they are emitted before the `--` command separator, where the CLI's parser expects flags. If the CLI does in fact reject them for stdio servers, narrowing the stdio clause is a one-line follow-up.

## Tests

Seven additions to `test/codex_wrapper/commands/mcp_test.exs`, following the existing `binary: "echo"` arg-echo convention:

- `add/4` http with both OAuth flags; stdio with `--oauth-client-id` asserted to precede `-- npx`; both flags absent when unset
- `login/3` bare, with a scope list joined to `read,write`, and with a scope string passed through
- `logout/2` bare

## Gates

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` (252 passed)
- [x] `mix dialyzer` (0 errors)
- [x] `mix docs`
- [ ] `mix credo --strict` -- cannot run locally (credo 1.7.17 crashes with a `FunctionClauseError` in `Credo.Code.Token.position/1` on Elixir 1.20.2 sigil tokens in `test/codex_wrapper/json_line_event_test.exs`, unrelated to this change); CI's pinned Elixir 1.19 / OTP 27 covers it

## Base

Branched from `origin/main` (`9a2fdd2`), so this does not stack on the four PRs already open (#73, #74, #75, #76). No file overlap with any of them.
