### PR TITLE
feat: add Commands.Archive for codex archive, unarchive, and delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,41 @@ alias CodexWrapper.Commands.Completion
 {:ok, script} = Completion.generate(config, :zsh)
 ```
 
+## Session lifecycle
+
+`codex archive`, `codex unarchive`, and `codex delete` operate on a saved
+session, named by id (UUID) or session name.
+
+```elixir
+alias CodexWrapper.Commands.Archive
+
+{:ok, _} = Archive.archive(config, "abc-123")
+{:ok, _} = Archive.unarchive(config, "abc-123")
+```
+
+`delete` permanently destroys the session, and `unarchive` cannot bring
+it back. So it requires an explicit confirmation; without it the CLI is
+never invoked.
+
+```elixir
+Archive.delete(config, "abc-123")
+# => {:error, :confirmation_required}
+
+Archive.delete(config, "abc-123", confirm: true)
+# => {:ok, ""}
+```
+
+The same three are available on a `%Session{}`, using its session id:
+
+```elixir
+{:ok, _} = CodexWrapper.Session.archive(session)
+{:ok, _} = CodexWrapper.Session.unarchive(session)
+{:ok, _} = CodexWrapper.Session.delete(session, confirm: true)
+```
+
+They return `{:error, :no_session}` if no turn has run yet, since the
+session id only exists once the CLI has created it.
+
 ## Applying diffs
 
 ```elixir
@@ -441,6 +476,7 @@ The streaming paths (`Exec.stream/2` and friends) still use the built-in
 | `CodexWrapper.Commands.Sandbox` | Sandboxed command execution |
 | `CodexWrapper.Commands.Fork` | Session forking |
 | `CodexWrapper.Commands.Apply` | Apply diffs from task IDs |
+| `CodexWrapper.Commands.Archive` | Archive, unarchive, and delete saved sessions |
 | `CodexWrapper.Commands.Completion` | Shell completion script generation |
 | `CodexWrapper.Commands.Version` | CLI version |
 

--- a/lib/codex_wrapper/commands/archive.ex
+++ b/lib/codex_wrapper/commands/archive.ex
@@ -1,0 +1,118 @@
+defmodule CodexWrapper.Commands.Archive do
+  @moduledoc """
+  Session lifecycle commands -- archive, unarchive, and delete a saved session.
+
+  Wraps `codex archive <session>`, `codex unarchive <session>`, and
+  `codex delete <session>`. Each takes a session id (UUID) or a session
+  name; the CLI prefers the UUID interpretation when the argument parses
+  as one.
+
+  ## Usage
+
+      config = CodexWrapper.Config.new()
+
+      {:ok, _} = CodexWrapper.Commands.Archive.archive(config, "abc-123")
+      {:ok, _} = CodexWrapper.Commands.Archive.unarchive(config, "abc-123")
+
+  ## Deleting
+
+  `codex delete` permanently destroys the saved session; there is no
+  undo, and `unarchive/2` cannot bring it back. So `delete/3` will not
+  run unless the caller passes `confirm: true`:
+
+      CodexWrapper.Commands.Archive.delete(config, "abc-123")
+      #=> {:error, :confirmation_required}
+
+      CodexWrapper.Commands.Archive.delete(config, "abc-123", confirm: true)
+      #=> {:ok, ""}
+
+  Without the flag the CLI is never invoked, so a delete reached by
+  mistake -- a wrong branch, a stale variable -- costs nothing. Archiving
+  is the reversible option and should be the default reach.
+  """
+
+  @behaviour CodexWrapper.Command
+
+  alias CodexWrapper.{Command, Config}
+
+  @type action :: :archive | :unarchive | :delete
+
+  @type t :: %__MODULE__{
+          action: action(),
+          session: String.t()
+        }
+
+  defstruct [:action, :session]
+
+  @actions [:archive, :unarchive, :delete]
+
+  # --- Constructor ---
+
+  @doc """
+  Build a lifecycle command for the given action and session.
+
+  The session is an id (UUID) or a session name.
+  """
+  @spec new(action(), String.t()) :: t()
+  def new(action, session) when action in @actions and is_binary(session) do
+    %__MODULE__{action: action, session: session}
+  end
+
+  # --- Execution ---
+
+  @doc """
+  Archive a saved session. Reversible with `unarchive/2`.
+  """
+  @spec archive(Config.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def archive(%Config{} = config, session) when is_binary(session) do
+    Command.run(__MODULE__, new(:archive, session), config)
+  end
+
+  @doc """
+  Unarchive a previously archived session.
+  """
+  @spec unarchive(Config.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def unarchive(%Config{} = config, session) when is_binary(session) do
+    Command.run(__MODULE__, new(:unarchive, session), config)
+  end
+
+  @doc """
+  Permanently delete a saved session.
+
+  Requires `confirm: true`. Without it this returns
+  `{:error, :confirmation_required}` and the CLI is not invoked. See the
+  module docs for why.
+
+  ## Options
+
+    * `:confirm` - must be `true` for the delete to run
+  """
+  @spec delete(Config.t(), String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, :confirmation_required | term()}
+  def delete(%Config{} = config, session, opts \\ []) when is_binary(session) do
+    if Keyword.get(opts, :confirm) == true do
+      Command.run(__MODULE__, new(:delete, session), config)
+    else
+      {:error, :confirmation_required}
+    end
+  end
+
+  # --- Arg building ---
+
+  @doc """
+  Build the argument list for an action and session.
+  """
+  @spec build_args(action(), String.t()) :: [String.t()]
+  def build_args(action, session) when action in @actions and is_binary(session) do
+    args(new(action, session))
+  end
+
+  @impl true
+  def args(%__MODULE__{action: action, session: session}) do
+    [Atom.to_string(action), session]
+  end
+
+  @impl true
+  def parse_output(stdout, 0), do: {:ok, String.trim(stdout)}
+  def parse_output(stdout, exit_code), do: {:error, {:exit, exit_code, stdout}}
+end

--- a/lib/codex_wrapper/session.ex
+++ b/lib/codex_wrapper/session.ex
@@ -24,6 +24,7 @@ defmodule CodexWrapper.Session do
       session = CodexWrapper.Session.resume(config, "session-id-abc")
   """
 
+  alias CodexWrapper.Commands.Archive
   alias CodexWrapper.{Config, Exec, ExecResume, JsonLineEvent, Result}
 
   @type t :: %__MODULE__{
@@ -153,6 +154,45 @@ defmodule CodexWrapper.Session do
   @spec last_result(t()) :: Result.t() | nil
   def last_result(%__MODULE__{history: []}), do: nil
   def last_result(%__MODULE__{history: history}), do: List.last(history)
+
+  @doc """
+  Archive this session (`codex archive`). Reversible with `unarchive/1`.
+
+  Returns `{:error, :no_session}` if no turn has run yet, since the
+  session id only exists once the CLI has created it.
+  """
+  @spec archive(t()) :: {:ok, String.t()} | {:error, :no_session | term()}
+  def archive(%__MODULE__{session_id: nil}), do: {:error, :no_session}
+
+  def archive(%__MODULE__{session_id: sid, config: config}),
+    do: Archive.archive(config, sid)
+
+  @doc """
+  Unarchive this session (`codex unarchive`).
+
+  Returns `{:error, :no_session}` if no turn has run yet.
+  """
+  @spec unarchive(t()) :: {:ok, String.t()} | {:error, :no_session | term()}
+  def unarchive(%__MODULE__{session_id: nil}), do: {:error, :no_session}
+
+  def unarchive(%__MODULE__{session_id: sid, config: config}),
+    do: Archive.unarchive(config, sid)
+
+  @doc """
+  Permanently delete this session (`codex delete`).
+
+  Requires `confirm: true`, like `CodexWrapper.Commands.Archive.delete/3`
+  it delegates to; without it the CLI is not invoked. Returns
+  `{:error, :no_session}` if no turn has run yet.
+  """
+  @spec delete(t(), keyword()) ::
+          {:ok, String.t()} | {:error, :no_session | :confirmation_required | term()}
+  def delete(session, opts \\ [])
+
+  def delete(%__MODULE__{session_id: nil}, _opts), do: {:error, :no_session}
+
+  def delete(%__MODULE__{session_id: sid, config: config}, opts),
+    do: Archive.delete(config, sid, opts)
 
   # --- Private ---
 

--- a/test/codex_wrapper/commands/archive_test.exs
+++ b/test/codex_wrapper/commands/archive_test.exs
@@ -1,0 +1,86 @@
+defmodule CodexWrapper.Commands.ArchiveTest do
+  use ExUnit.Case, async: true
+
+  alias CodexWrapper.Commands.Archive
+  alias CodexWrapper.Config
+
+  describe "new/2" do
+    test "holds the action and session" do
+      command = Archive.new(:archive, "abc-123")
+      assert command.action == :archive
+      assert command.session == "abc-123"
+    end
+  end
+
+  describe "build_args/2" do
+    test "archive" do
+      assert Archive.build_args(:archive, "abc-123") == ["archive", "abc-123"]
+    end
+
+    test "unarchive" do
+      assert Archive.build_args(:unarchive, "abc-123") == ["unarchive", "abc-123"]
+    end
+
+    test "delete" do
+      assert Archive.build_args(:delete, "abc-123") == ["delete", "abc-123"]
+    end
+
+    test "passes a session name through unchanged" do
+      assert Archive.build_args(:archive, "nightly-triage") == ["archive", "nightly-triage"]
+    end
+
+    test "agrees with args/1" do
+      assert Archive.build_args(:delete, "abc-123") ==
+               Archive.args(Archive.new(:delete, "abc-123"))
+    end
+  end
+
+  describe "delete/3" do
+    test "refuses without confirm: true and does not invoke the CLI" do
+      # `binary: "false"` would exit 1 if the command ran at all.
+      config = Config.new(binary: "false")
+      assert Archive.delete(config, "abc-123") == {:error, :confirmation_required}
+    end
+
+    test "refuses confirm: false" do
+      config = Config.new(binary: "false")
+      assert Archive.delete(config, "abc-123", confirm: false) == {:error, :confirmation_required}
+    end
+
+    test "refuses a truthy non-true confirm value" do
+      config = Config.new(binary: "false")
+      assert Archive.delete(config, "abc-123", confirm: "yes") == {:error, :confirmation_required}
+    end
+
+    test "runs when confirmed" do
+      config = Config.new(binary: "echo")
+      assert {:ok, output} = Archive.delete(config, "abc-123", confirm: true)
+      assert output =~ "delete abc-123"
+    end
+  end
+
+  describe "execution" do
+    test "archive/2 invokes the archive subcommand" do
+      config = Config.new(binary: "echo")
+      assert {:ok, output} = Archive.archive(config, "abc-123")
+      assert output =~ "archive abc-123"
+    end
+
+    test "unarchive/2 invokes the unarchive subcommand" do
+      config = Config.new(binary: "echo")
+      assert {:ok, output} = Archive.unarchive(config, "abc-123")
+      assert output =~ "unarchive abc-123"
+    end
+  end
+
+  describe "parse_output/2" do
+    test "trims stdout on exit 0" do
+      assert Archive.parse_output("  done\n", 0) == {:ok, "done"}
+    end
+
+    test "reports a nonzero exit" do
+      assert Archive.parse_output("no such session\n", 1) ==
+               {:error, {:exit, 1, "no such session\n"}}
+    end
+  end
+end

--- a/test/codex_wrapper/session_test.exs
+++ b/test/codex_wrapper/session_test.exs
@@ -135,4 +135,32 @@ defmodule CodexWrapper.SessionTest do
       assert Session.extract_session_id([]) == nil
     end
   end
+
+  describe "archive/1, unarchive/1, delete/2" do
+    test "archive/1 archives the session id" do
+      session = Session.resume(Config.new(binary: "echo"), "abc-123")
+      assert {:ok, output} = Session.archive(session)
+      assert output =~ "archive abc-123"
+    end
+
+    test "unarchive/1 unarchives the session id" do
+      session = Session.resume(Config.new(binary: "echo"), "abc-123")
+      assert {:ok, output} = Session.unarchive(session)
+      assert output =~ "unarchive abc-123"
+    end
+
+    test "delete/2 requires confirm: true" do
+      session = Session.resume(Config.new(binary: "echo"), "abc-123")
+      assert Session.delete(session) == {:error, :confirmation_required}
+      assert {:ok, output} = Session.delete(session, confirm: true)
+      assert output =~ "delete abc-123"
+    end
+
+    test "all three refuse a session with no id yet" do
+      session = Session.new(Config.new(binary: "false"))
+      assert Session.archive(session) == {:error, :no_session}
+      assert Session.unarchive(session) == {:error, :no_session}
+      assert Session.delete(session, confirm: true) == {:error, :no_session}
+    end
+  end
 end


### PR DESCRIPTION
Closes #62. Part of #52 (Codex CLI 0.145.0 compatibility), Phase 2 additive set.

## Change

codex-cli 0.145.0 has three session lifecycle subcommands the wrapper did not cover. Verified against the real binary (codex-cli 0.145.0):

```
$ codex archive --help
Archive a saved session by id or session name
Usage: codex archive [OPTIONS] <SESSION>
Arguments:
  <SESSION>  Session id (UUID) or session name. UUIDs take precedence if it parses
```

`unarchive` and `delete` have the identical shape (`delete` is described as "Permanently delete a saved session by id or session name"). None of the three take a subcommand-specific option; everything in their `--help` is the shared global option set.

- `CodexWrapper.Commands.Archive` implementing `CodexWrapper.Command`, with `archive/2`, `unarchive/2`, `delete/3`, and a `new/2` constructor over a small `%Archive{action: action, session: session}` struct
- Execution routed through `Command.run/3`, so these get the same stdin-closing and runner/timeout handling as `Exec` and `Sandbox`
- `Session.archive/1`, `Session.unarchive/1`, `Session.delete/2` delegating with the session's own `session_id`
- README: a "Session lifecycle" section plus a `Commands.Archive` row in the Modules table

Purely additive.

## The delete safety story

The issue asked to decide how `delete` is guarded, since it destroys session state and `unarchive` cannot bring it back.

`delete/3` requires an explicit `confirm: true`. Without it the function returns `{:error, :confirmation_required}` and the CLI is **not invoked at all**, so a delete reached by mistake costs nothing:

```elixir
Archive.delete(config, "abc-123")
# => {:error, :confirmation_required}

Archive.delete(config, "abc-123", confirm: true)
# => {:ok, ""}
```

The check is `Keyword.get(opts, :confirm) == true`, not a truthiness test, so a stray non-boolean does not open the gate. `Session.delete/2` inherits the same requirement by delegating. Archiving stays reachable without any flag, which is the intended default reach.

## Session wrappers

The issue suggested convenience wrappers taking a `%Session{}`. All three return `{:error, :no_session}` when `session_id` is `nil`, which is the state a `Session.new/2` sits in until its first turn completes; there is no id to name yet, and the alternative would be passing `nil` to the CLI as a session argument.

## Tests

Fourteen new tests. The execution paths use the existing `binary: "echo"` arg-echo convention from `mcp_test.exs`, so `Command.run/3` really does run and the emitted argv is observable without the real binary.

- `archive_test.exs`: `new/2`, `build_args/2` for all three actions plus a session-name case and a `build_args/2` == `args/1` agreement check, `delete/3` refusing bare / `confirm: false` / `confirm: "yes"` (with `binary: "false"`, which would exit nonzero if the command ran at all) and running under `confirm: true`, `archive/2` and `unarchive/2` execution, and `parse_output/2` on both exit paths
- `session_test.exs`: `archive/1`, `unarchive/1`, `delete/2` both refused and confirmed, and all three returning `{:error, :no_session}` before a session id exists

## Gates

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` (263 passed)
- [x] `mix dialyzer` (0 errors)
- [x] `mix docs`
- [x] `mix credo --strict` on the four changed files -- clean

A note on that last one: `mix credo --strict` with no arguments still crashes locally (`FunctionClauseError` in `Credo.Code.Token.position/1` on Elixir 1.20.2 sigil tokens in `test/codex_wrapper/json_line_event_test.exs`, unrelated to this change). Passing the changed files explicitly skips the file that trips it and runs all 69 checks on the diff, which is a real signal earlier PRs in this series left to CI. It caught one alias-ordering issue in `session.ex`, fixed before commit.

## Base

Branched from `origin/main` (`9a2fdd2`). Does not stack on the five PRs already open (#73, #74, #75, #76, #77); the only shared file is `README.md`, and the additions sit in different sections.
