### PR TITLE
feat: add config-isolation and trust flags to the exec builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,46 @@ Both emit `-c web_search="<mode>"`. The Codex CLI removed the `--search`
 flag from `exec` in 0.14x; the config key is the supported equivalent,
 and `:live` is what `--search` used to mean.
 
+### Config isolation
+
+By default the CLI loads `$CODEX_HOME/config.toml`, so a programmatic run
+silently inherits whatever the developer has configured. Two options take
+that away:
+
+```elixir
+Exec.new("Summarize the diff")
+|> Exec.ignore_user_config()
+|> Exec.strict_config()
+|> Exec.config(~s(model="o3"))
+|> Exec.execute(config)
+```
+
+`ignore_user_config/1` skips the config file entirely (auth still
+resolves through `CODEX_HOME`). `strict_config/1` makes the run fail on a
+config key this Codex version does not recognize, rather than ignoring
+it. Together they give a run whose configuration is exactly what the
+caller passed.
+
+`ignore_rules/1` is the same idea for execpolicy `.rules` files.
+
+All three are available on `Exec`, `ExecResume`, and `Review`.
+
+### Hook trust
+
+`dangerously_bypass_hook_trust/1` runs enabled hooks without requiring
+persisted hook trust. Hook trust is what stops a repository from running
+commands the user never approved, so this belongs only in automation that
+already vets where its hooks come from. It is separate from
+`dangerously_bypass_approvals_and_sandbox/1`; setting one does not set the
+other. Available on `Exec`, `ExecResume`, and `Review`.
+
+### Color and local providers
+
+`color/2` (`:always`, `:never`, `:auto`), `oss/1`, and `local_provider/2`
+(`"lmstudio"` or `"ollama"`) are on `Exec` only. `codex exec resume` and
+`codex exec review` reject `--color`, `--oss`, and `--local-provider`,
+verified against codex-cli 0.145.0.
+
 ## Review builder
 
 ```elixir
@@ -414,6 +454,13 @@ The streaming paths (`Exec.stream/2` and friends) still use the built-in
 | `:json` | `boolean()` | Enable JSON (NDJSON) output |
 | `:output_schema` | `String.t()` | Path to output schema file |
 | `:output_last_message` | `String.t()` | Path to save last message |
+| `:strict_config` | `boolean()` | Fail on unrecognized `config.toml` keys |
+| `:ignore_user_config` | `boolean()` | Skip `$CODEX_HOME/config.toml` |
+| `:ignore_rules` | `boolean()` | Skip execpolicy `.rules` files |
+| `:dangerously_bypass_hook_trust` | `boolean()` | Run hooks without persisted trust |
+| `:color` | atom | `:always`, `:never`, or `:auto` (Exec only) |
+| `:oss` | `boolean()` | Use an open-source provider (Exec only) |
+| `:local_provider` | `String.t()` | `"lmstudio"` or `"ollama"` (Exec only) |
 
 ## Modules
 

--- a/lib/codex_wrapper/exec.ex
+++ b/lib/codex_wrapper/exec.ex
@@ -25,6 +25,7 @@ defmodule CodexWrapper.Exec do
   @type sandbox_mode :: :read_only | :workspace_write | :danger_full_access
   @type approval_policy :: :untrusted | :on_request | :never
   @type web_search_mode :: :cached | :indexed | :live | :disabled
+  @type color_mode :: :always | :never | :auto
 
   @type t :: %__MODULE__{
           prompt: String.t(),
@@ -33,6 +34,7 @@ defmodule CodexWrapper.Exec do
           approval_policy: approval_policy() | nil,
           full_auto: boolean(),
           dangerously_bypass_approvals_and_sandbox: boolean(),
+          dangerously_bypass_hook_trust: boolean(),
           cd: String.t() | nil,
           skip_git_repo_check: boolean(),
           add_dirs: [String.t()],
@@ -44,7 +46,13 @@ defmodule CodexWrapper.Exec do
           images: [String.t()],
           config_overrides: [String.t()],
           enabled_features: [String.t()],
-          disabled_features: [String.t()]
+          disabled_features: [String.t()],
+          strict_config: boolean(),
+          ignore_user_config: boolean(),
+          ignore_rules: boolean(),
+          color: color_mode() | nil,
+          oss: boolean(),
+          local_provider: String.t() | nil
         }
 
   defstruct [
@@ -56,8 +64,11 @@ defmodule CodexWrapper.Exec do
     :output_schema,
     :output_last_message,
     :search,
+    :color,
+    :local_provider,
     full_auto: false,
     dangerously_bypass_approvals_and_sandbox: false,
+    dangerously_bypass_hook_trust: false,
     skip_git_repo_check: false,
     ephemeral: false,
     json: false,
@@ -65,7 +76,11 @@ defmodule CodexWrapper.Exec do
     images: [],
     config_overrides: [],
     enabled_features: [],
-    disabled_features: []
+    disabled_features: [],
+    strict_config: false,
+    ignore_user_config: false,
+    ignore_rules: false,
+    oss: false
   ]
 
   # --- Constructor ---
@@ -126,6 +141,64 @@ defmodule CodexWrapper.Exec do
   @spec dangerously_bypass_approvals_and_sandbox(t()) :: t()
   def dangerously_bypass_approvals_and_sandbox(%__MODULE__{} = e),
     do: %{e | dangerously_bypass_approvals_and_sandbox: true}
+
+  @doc """
+  Run enabled hooks without requiring persisted hook trust. Use with extreme caution.
+
+  Hook trust is what stops a repository from running arbitrary commands
+  the user never approved. Only appropriate for automation that already
+  vets where its hooks come from.
+  """
+  @spec dangerously_bypass_hook_trust(t()) :: t()
+  def dangerously_bypass_hook_trust(%__MODULE__{} = e),
+    do: %{e | dangerously_bypass_hook_trust: true}
+
+  @doc """
+  Error out when `config.toml` contains fields this Codex version does not recognize.
+
+  Turns a silently-ignored typo in a config file into a failed run, which
+  is usually what a programmatic caller wants.
+  """
+  @spec strict_config(t()) :: t()
+  def strict_config(%__MODULE__{} = e), do: %{e | strict_config: true}
+
+  @doc """
+  Do not load `$CODEX_HOME/config.toml`.
+
+  Auth still resolves through `CODEX_HOME`; only the config file is
+  skipped. Pair with `config/2` overrides for a run that does not pick up
+  the developer's personal settings.
+  """
+  @spec ignore_user_config(t()) :: t()
+  def ignore_user_config(%__MODULE__{} = e), do: %{e | ignore_user_config: true}
+
+  @doc "Do not load user or project execpolicy `.rules` files."
+  @spec ignore_rules(t()) :: t()
+  def ignore_rules(%__MODULE__{} = e), do: %{e | ignore_rules: true}
+
+  @doc """
+  Set the color mode: `:always`, `:never`, or `:auto`.
+
+  The CLI defaults to `:auto`, which already suppresses color when stdout
+  is not a terminal. `:never` is worth setting explicitly when the output
+  is parsed.
+  """
+  @spec color(t(), color_mode()) :: t()
+  def color(%__MODULE__{} = e, mode) when mode in [:always, :never, :auto],
+    do: %{e | color: mode}
+
+  @doc "Use an open-source provider instead of the default."
+  @spec oss(t()) :: t()
+  def oss(%__MODULE__{} = e), do: %{e | oss: true}
+
+  @doc """
+  Select which local provider to use (`"lmstudio"` or `"ollama"`).
+
+  Meaningful alongside `oss/1`; without it the CLI uses the config
+  default or prompts for a selection.
+  """
+  @spec local_provider(t(), String.t()) :: t()
+  def local_provider(%__MODULE__{} = e, provider), do: %{e | local_provider: provider}
 
   @doc "Set the working directory for the codex subprocess."
   @spec cd(t(), String.t()) :: t()
@@ -280,18 +353,25 @@ defmodule CodexWrapper.Exec do
     |> add_list("-c", config_overrides(e))
     |> add_list("--enable", e.enabled_features)
     |> add_list("--disable", e.disabled_features)
+    |> add_bool("--strict-config", e.strict_config)
     |> add_list("--image", e.images)
     |> add_opt("--model", e.model)
+    |> add_bool("--oss", e.oss)
+    |> add_opt("--local-provider", e.local_provider)
     |> add_opt("--sandbox", format_sandbox(effective_sandbox(e)))
     |> add_bool(
       "--dangerously-bypass-approvals-and-sandbox",
       e.dangerously_bypass_approvals_and_sandbox
     )
+    |> add_bool("--dangerously-bypass-hook-trust", e.dangerously_bypass_hook_trust)
     |> add_opt("--cd", e.cd)
     |> add_bool("--skip-git-repo-check", e.skip_git_repo_check)
     |> add_list("--add-dir", e.add_dirs)
     |> add_bool("--ephemeral", e.ephemeral)
+    |> add_bool("--ignore-user-config", e.ignore_user_config)
+    |> add_bool("--ignore-rules", e.ignore_rules)
     |> add_opt("--output-schema", e.output_schema)
+    |> add_opt("--color", format_color(e.color))
     |> add_bool("--json", e.json)
     |> add_opt("--output-last-message", e.output_last_message)
     |> add_flag(e.prompt)
@@ -330,6 +410,11 @@ defmodule CodexWrapper.Exec do
   defp format_sandbox(:read_only), do: "read-only"
   defp format_sandbox(:workspace_write), do: "workspace-write"
   defp format_sandbox(:danger_full_access), do: "danger-full-access"
+
+  defp format_color(nil), do: nil
+  defp format_color(:always), do: "always"
+  defp format_color(:never), do: "never"
+  defp format_color(:auto), do: "auto"
 
   # `--search` and `--ask-for-approval` were both removed from `codex exec`
   # in 0.14x; their config keys are the supported equivalents, so both

--- a/lib/codex_wrapper/exec_resume.ex
+++ b/lib/codex_wrapper/exec_resume.ex
@@ -38,6 +38,7 @@ defmodule CodexWrapper.ExecResume do
           sandbox: sandbox_mode() | nil,
           full_auto: boolean(),
           dangerously_bypass_approvals_and_sandbox: boolean(),
+          dangerously_bypass_hook_trust: boolean(),
           skip_git_repo_check: boolean(),
           ephemeral: boolean(),
           json: boolean(),
@@ -45,7 +46,10 @@ defmodule CodexWrapper.ExecResume do
           images: [String.t()],
           config_overrides: [String.t()],
           enabled_features: [String.t()],
-          disabled_features: [String.t()]
+          disabled_features: [String.t()],
+          strict_config: boolean(),
+          ignore_user_config: boolean(),
+          ignore_rules: boolean()
         }
 
   defstruct [
@@ -58,13 +62,17 @@ defmodule CodexWrapper.ExecResume do
     all: false,
     full_auto: false,
     dangerously_bypass_approvals_and_sandbox: false,
+    dangerously_bypass_hook_trust: false,
     skip_git_repo_check: false,
     ephemeral: false,
     json: false,
     images: [],
     config_overrides: [],
     enabled_features: [],
-    disabled_features: []
+    disabled_features: [],
+    strict_config: false,
+    ignore_user_config: false,
+    ignore_rules: false
   ]
 
   # --- Constructor ---
@@ -115,6 +123,40 @@ defmodule CodexWrapper.ExecResume do
   @spec dangerously_bypass_approvals_and_sandbox(t()) :: t()
   def dangerously_bypass_approvals_and_sandbox(%__MODULE__{} = e),
     do: %{e | dangerously_bypass_approvals_and_sandbox: true}
+
+  @doc """
+  Run enabled hooks without requiring persisted hook trust. Use with extreme caution.
+
+  Hook trust is what stops a repository from running arbitrary commands
+  the user never approved. Only appropriate for automation that already
+  vets where its hooks come from.
+  """
+  @spec dangerously_bypass_hook_trust(t()) :: t()
+  def dangerously_bypass_hook_trust(%__MODULE__{} = e),
+    do: %{e | dangerously_bypass_hook_trust: true}
+
+  @doc """
+  Error out when `config.toml` contains fields this Codex version does not recognize.
+
+  Turns a silently-ignored typo in a config file into a failed run, which
+  is usually what a programmatic caller wants.
+  """
+  @spec strict_config(t()) :: t()
+  def strict_config(%__MODULE__{} = e), do: %{e | strict_config: true}
+
+  @doc """
+  Do not load `$CODEX_HOME/config.toml`.
+
+  Auth still resolves through `CODEX_HOME`; only the config file is
+  skipped. Pair with `config/2` overrides for a run that does not pick up
+  the developer's personal settings.
+  """
+  @spec ignore_user_config(t()) :: t()
+  def ignore_user_config(%__MODULE__{} = e), do: %{e | ignore_user_config: true}
+
+  @doc "Do not load user or project execpolicy `.rules` files."
+  @spec ignore_rules(t()) :: t()
+  def ignore_rules(%__MODULE__{} = e), do: %{e | ignore_rules: true}
 
   @doc "Skip the git repo check."
   @spec skip_git_repo_check(t()) :: t()
@@ -236,14 +278,18 @@ defmodule CodexWrapper.ExecResume do
     |> add_bool("--last", e.last)
     |> add_bool("--all", e.all)
     |> add_list("--image", e.images)
+    |> add_bool("--strict-config", e.strict_config)
     |> add_opt("--model", e.model)
     |> add_opt("--sandbox", format_sandbox(effective_sandbox(e)))
     |> add_bool(
       "--dangerously-bypass-approvals-and-sandbox",
       e.dangerously_bypass_approvals_and_sandbox
     )
+    |> add_bool("--dangerously-bypass-hook-trust", e.dangerously_bypass_hook_trust)
     |> add_bool("--skip-git-repo-check", e.skip_git_repo_check)
     |> add_bool("--ephemeral", e.ephemeral)
+    |> add_bool("--ignore-user-config", e.ignore_user_config)
+    |> add_bool("--ignore-rules", e.ignore_rules)
     |> add_bool("--json", e.json)
     |> add_opt("--output-last-message", e.output_last_message)
     |> add_opt_flag(e.session_id)

--- a/lib/codex_wrapper/review.ex
+++ b/lib/codex_wrapper/review.ex
@@ -42,13 +42,17 @@ defmodule CodexWrapper.Review do
           sandbox: sandbox_mode() | nil,
           full_auto: boolean(),
           dangerously_bypass_approvals_and_sandbox: boolean(),
+          dangerously_bypass_hook_trust: boolean(),
           skip_git_repo_check: boolean(),
           ephemeral: boolean(),
           json: boolean(),
           output_last_message: String.t() | nil,
           config_overrides: [String.t()],
           enabled_features: [String.t()],
-          disabled_features: [String.t()]
+          disabled_features: [String.t()],
+          strict_config: boolean(),
+          ignore_user_config: boolean(),
+          ignore_rules: boolean()
         }
 
   defstruct [
@@ -62,12 +66,16 @@ defmodule CodexWrapper.Review do
     uncommitted: false,
     full_auto: false,
     dangerously_bypass_approvals_and_sandbox: false,
+    dangerously_bypass_hook_trust: false,
     skip_git_repo_check: false,
     ephemeral: false,
     json: false,
     config_overrides: [],
     enabled_features: [],
-    disabled_features: []
+    disabled_features: [],
+    strict_config: false,
+    ignore_user_config: false,
+    ignore_rules: false
   ]
 
   # --- Constructor ---
@@ -122,6 +130,40 @@ defmodule CodexWrapper.Review do
   @spec dangerously_bypass_approvals_and_sandbox(t()) :: t()
   def dangerously_bypass_approvals_and_sandbox(%__MODULE__{} = r),
     do: %{r | dangerously_bypass_approvals_and_sandbox: true}
+
+  @doc """
+  Run enabled hooks without requiring persisted hook trust. Use with extreme caution.
+
+  Hook trust is what stops a repository from running arbitrary commands
+  the user never approved. Only appropriate for automation that already
+  vets where its hooks come from.
+  """
+  @spec dangerously_bypass_hook_trust(t()) :: t()
+  def dangerously_bypass_hook_trust(%__MODULE__{} = r),
+    do: %{r | dangerously_bypass_hook_trust: true}
+
+  @doc """
+  Error out when `config.toml` contains fields this Codex version does not recognize.
+
+  Turns a silently-ignored typo in a config file into a failed run, which
+  is usually what a programmatic caller wants.
+  """
+  @spec strict_config(t()) :: t()
+  def strict_config(%__MODULE__{} = r), do: %{r | strict_config: true}
+
+  @doc """
+  Do not load `$CODEX_HOME/config.toml`.
+
+  Auth still resolves through `CODEX_HOME`; only the config file is
+  skipped. Pair with `config/2` overrides for a run that does not pick up
+  the developer's personal settings.
+  """
+  @spec ignore_user_config(t()) :: t()
+  def ignore_user_config(%__MODULE__{} = r), do: %{r | ignore_user_config: true}
+
+  @doc "Do not load user or project execpolicy `.rules` files."
+  @spec ignore_rules(t()) :: t()
+  def ignore_rules(%__MODULE__{} = r), do: %{r | ignore_rules: true}
 
   @doc "Skip the git repo check."
   @spec skip_git_repo_check(t()) :: t()
@@ -239,6 +281,7 @@ defmodule CodexWrapper.Review do
     |> add_bool("--uncommitted", r.uncommitted)
     |> add_opt("--base", r.base)
     |> add_opt("--commit", r.commit)
+    |> add_bool("--strict-config", r.strict_config)
     |> add_opt("--model", r.model)
     |> add_opt("--title", r.title)
     |> add_opt("--sandbox", format_sandbox(effective_sandbox(r)))
@@ -246,8 +289,11 @@ defmodule CodexWrapper.Review do
       "--dangerously-bypass-approvals-and-sandbox",
       r.dangerously_bypass_approvals_and_sandbox
     )
+    |> add_bool("--dangerously-bypass-hook-trust", r.dangerously_bypass_hook_trust)
     |> add_bool("--skip-git-repo-check", r.skip_git_repo_check)
     |> add_bool("--ephemeral", r.ephemeral)
+    |> add_bool("--ignore-user-config", r.ignore_user_config)
+    |> add_bool("--ignore-rules", r.ignore_rules)
     |> add_bool("--json", r.json)
     |> add_opt("--output-last-message", r.output_last_message)
     |> add_prompt(r.prompt)

--- a/test/codex_wrapper/exec_resume_test.exs
+++ b/test/codex_wrapper/exec_resume_test.exs
@@ -21,6 +21,10 @@ defmodule CodexWrapper.ExecResumeTest do
       assert exec.config_overrides == []
       assert exec.enabled_features == []
       assert exec.disabled_features == []
+      assert exec.strict_config == false
+      assert exec.ignore_user_config == false
+      assert exec.ignore_rules == false
+      assert exec.dangerously_bypass_hook_trust == false
     end
   end
 
@@ -245,6 +249,56 @@ defmodule CodexWrapper.ExecResumeTest do
     test "no --sandbox when neither is set" do
       args = ExecResume.new() |> ExecResume.args()
       refute "--sandbox" in args
+    end
+  end
+
+  describe "config and trust flags" do
+    test "strict_config/1" do
+      exec = ExecResume.new() |> ExecResume.strict_config()
+      assert exec.strict_config == true
+      assert "--strict-config" in ExecResume.args(exec)
+    end
+
+    test "ignore_user_config/1" do
+      exec = ExecResume.new() |> ExecResume.ignore_user_config()
+      assert exec.ignore_user_config == true
+      assert "--ignore-user-config" in ExecResume.args(exec)
+    end
+
+    test "ignore_rules/1" do
+      exec = ExecResume.new() |> ExecResume.ignore_rules()
+      assert exec.ignore_rules == true
+      assert "--ignore-rules" in ExecResume.args(exec)
+    end
+
+    test "dangerously_bypass_hook_trust/1" do
+      exec = ExecResume.new() |> ExecResume.dangerously_bypass_hook_trust()
+      assert exec.dangerously_bypass_hook_trust == true
+      assert "--dangerously-bypass-hook-trust" in ExecResume.args(exec)
+    end
+
+    test "flags precede the positional session id and prompt" do
+      args =
+        ExecResume.new()
+        |> ExecResume.session_id("abc-123")
+        |> ExecResume.prompt("continue")
+        |> ExecResume.strict_config()
+        |> ExecResume.ignore_user_config()
+        |> ExecResume.args()
+
+      assert List.last(args) == "continue"
+      assert Enum.at(args, -2) == "abc-123"
+      assert Enum.find_index(args, &(&1 == "--strict-config")) < length(args) - 2
+      assert Enum.find_index(args, &(&1 == "--ignore-user-config")) < length(args) - 2
+    end
+
+    test "none of the flags are emitted when unset" do
+      args = ExecResume.new() |> ExecResume.args()
+
+      refute "--strict-config" in args
+      refute "--ignore-user-config" in args
+      refute "--ignore-rules" in args
+      refute "--dangerously-bypass-hook-trust" in args
     end
   end
 end

--- a/test/codex_wrapper/exec_test.exs
+++ b/test/codex_wrapper/exec_test.exs
@@ -28,6 +28,13 @@ defmodule CodexWrapper.ExecTest do
       assert exec.config_overrides == []
       assert exec.enabled_features == []
       assert exec.disabled_features == []
+      assert exec.strict_config == false
+      assert exec.ignore_user_config == false
+      assert exec.ignore_rules == false
+      assert exec.dangerously_bypass_hook_trust == false
+      assert exec.color == nil
+      assert exec.oss == false
+      assert exec.local_provider == nil
     end
   end
 
@@ -360,6 +367,97 @@ defmodule CodexWrapper.ExecTest do
     test "no --sandbox when neither is set" do
       args = Exec.new("p") |> Exec.args()
       refute "--sandbox" in args
+    end
+  end
+
+  describe "config and trust flags" do
+    test "strict_config/1" do
+      exec = Exec.new("p") |> Exec.strict_config()
+      assert exec.strict_config == true
+      assert "--strict-config" in Exec.args(exec)
+    end
+
+    test "ignore_user_config/1" do
+      exec = Exec.new("p") |> Exec.ignore_user_config()
+      assert exec.ignore_user_config == true
+      assert "--ignore-user-config" in Exec.args(exec)
+    end
+
+    test "ignore_rules/1" do
+      exec = Exec.new("p") |> Exec.ignore_rules()
+      assert exec.ignore_rules == true
+      assert "--ignore-rules" in Exec.args(exec)
+    end
+
+    test "dangerously_bypass_hook_trust/1" do
+      exec = Exec.new("p") |> Exec.dangerously_bypass_hook_trust()
+      assert exec.dangerously_bypass_hook_trust == true
+      assert "--dangerously-bypass-hook-trust" in Exec.args(exec)
+    end
+
+    test "the config-isolation pair composes" do
+      args =
+        Exec.new("p")
+        |> Exec.ignore_user_config()
+        |> Exec.strict_config()
+        |> Exec.config(~s(model="o3"))
+        |> Exec.args()
+
+      assert "--ignore-user-config" in args
+      assert "--strict-config" in args
+      assert ~s(model="o3") in args
+    end
+
+    test "none of the flags are emitted when unset" do
+      args = Exec.new("p") |> Exec.args()
+
+      refute "--strict-config" in args
+      refute "--ignore-user-config" in args
+      refute "--ignore-rules" in args
+      refute "--dangerously-bypass-hook-trust" in args
+    end
+
+    test "hook trust is independent of the approvals-and-sandbox bypass" do
+      args = Exec.new("p") |> Exec.dangerously_bypass_hook_trust() |> Exec.args()
+
+      assert "--dangerously-bypass-hook-trust" in args
+      refute "--dangerously-bypass-approvals-and-sandbox" in args
+    end
+  end
+
+  describe "color and provider options" do
+    test "color/2 accepts each mode" do
+      for {mode, flag} <- [always: "always", never: "never", auto: "auto"] do
+        args = Exec.new("p") |> Exec.color(mode) |> Exec.args()
+        idx = Enum.find_index(args, &(&1 == "--color"))
+        assert Enum.at(args, idx + 1) == flag
+      end
+    end
+
+    test "color/2 rejects an unknown mode" do
+      assert_raise FunctionClauseError, fn ->
+        Exec.new("p") |> Exec.color(:sometimes)
+      end
+    end
+
+    test "oss/1" do
+      exec = Exec.new("p") |> Exec.oss()
+      assert exec.oss == true
+      assert "--oss" in Exec.args(exec)
+    end
+
+    test "local_provider/2" do
+      args = Exec.new("p") |> Exec.oss() |> Exec.local_provider("ollama") |> Exec.args()
+      idx = Enum.find_index(args, &(&1 == "--local-provider"))
+      assert Enum.at(args, idx + 1) == "ollama"
+    end
+
+    test "neither is emitted when unset" do
+      args = Exec.new("p") |> Exec.args()
+
+      refute "--color" in args
+      refute "--oss" in args
+      refute "--local-provider" in args
     end
   end
 end

--- a/test/codex_wrapper/review_test.exs
+++ b/test/codex_wrapper/review_test.exs
@@ -21,6 +21,10 @@ defmodule CodexWrapper.ReviewTest do
       assert review.config_overrides == []
       assert review.enabled_features == []
       assert review.disabled_features == []
+      assert review.strict_config == false
+      assert review.ignore_user_config == false
+      assert review.ignore_rules == false
+      assert review.dangerously_bypass_hook_trust == false
     end
   end
 
@@ -255,6 +259,54 @@ defmodule CodexWrapper.ReviewTest do
     test "no --sandbox when neither is set" do
       args = Review.new() |> Review.args()
       refute "--sandbox" in args
+    end
+  end
+
+  describe "config and trust flags" do
+    test "strict_config/1" do
+      review = Review.new() |> Review.strict_config()
+      assert review.strict_config == true
+      assert "--strict-config" in Review.args(review)
+    end
+
+    test "ignore_user_config/1" do
+      review = Review.new() |> Review.ignore_user_config()
+      assert review.ignore_user_config == true
+      assert "--ignore-user-config" in Review.args(review)
+    end
+
+    test "ignore_rules/1" do
+      review = Review.new() |> Review.ignore_rules()
+      assert review.ignore_rules == true
+      assert "--ignore-rules" in Review.args(review)
+    end
+
+    test "dangerously_bypass_hook_trust/1" do
+      review = Review.new() |> Review.dangerously_bypass_hook_trust()
+      assert review.dangerously_bypass_hook_trust == true
+      assert "--dangerously-bypass-hook-trust" in Review.args(review)
+    end
+
+    test "flags precede the positional prompt" do
+      args =
+        Review.new()
+        |> Review.prompt("focus on correctness")
+        |> Review.strict_config()
+        |> Review.ignore_rules()
+        |> Review.args()
+
+      assert List.last(args) == "focus on correctness"
+      assert "--strict-config" in args
+      assert "--ignore-rules" in args
+    end
+
+    test "none of the flags are emitted when unset" do
+      args = Review.new() |> Review.args()
+
+      refute "--strict-config" in args
+      refute "--ignore-user-config" in args
+      refute "--ignore-rules" in args
+      refute "--dangerously-bypass-hook-trust" in args
     end
   end
 end


### PR DESCRIPTION
Closes #65. Part of #52 (Codex CLI 0.145.0 compatibility), Phase 2 additive set.

## Change

codex-cli 0.145.0 exposes several config and trust flags the wrapper did not cover. Every flag below was checked against the real binary (codex-cli 0.145.0) before being wired.

`Exec`, `ExecResume`, and `Review` each gain four builders:

- `strict_config/1` -> `--strict-config`
- `ignore_user_config/1` -> `--ignore-user-config`
- `ignore_rules/1` -> `--ignore-rules`
- `dangerously_bypass_hook_trust/1` -> `--dangerously-bypass-hook-trust`

`Exec` alone gains three more:

- `color/2` (`:always` | `:never` | `:auto`) -> `--color <mode>`
- `oss/1` -> `--oss`
- `local_provider/2` -> `--local-provider <name>`

Additive. No existing arg list changes when the new options are unset, and there are tests asserting that.

## The exec-only split

The issue asked for all of these on `Exec`, `ExecResume`, and `Review`. The CLI does not offer all of them there. `codex exec resume --help` and `codex exec review --help` list the four shared flags but not `--color`, `--oss`, or `--local-provider`, and the parser rejects them outright:

```
$ codex exec review --color
error: unexpected argument '--color' found

$ codex exec resume --oss
error: unexpected argument '--oss' found
```

So those three are on `Exec` only. Putting them on the other two builders would have produced argv the CLI refuses to parse.

## A finding outside this PR's scope

The same probe turned up two pre-existing cases of the wrapper emitting flags the subcommands reject:

- `--sandbox` is rejected by both `codex exec resume` and `codex exec review`, but `ExecResume.sandbox/2` and `Review.sandbox/2` emit it today (and `full_auto/1` translates into it on both).
- PR #73, still open, adds `--profile` to all three builders. `codex exec review --profile` and `codex exec resume --profile` both error with `unexpected argument`.

Both are separate from #65 and neither is touched here. Worth a follow-up issue.

## Tests

Nineteen additions across the three builder test files.

- `exec_test.exs`: each of the seven new builders sets its field and emits its flag; the `ignore_user_config` + `strict_config` + `config` composition; hook trust asserted independent of the approvals-and-sandbox bypass; `color/2` over all three modes plus a `FunctionClauseError` on an unknown one; nothing emitted when unset
- `exec_resume_test.exs`: the four shared builders, flags asserted to precede the positional session id and prompt, nothing emitted when unset
- `review_test.exs`: the four shared builders, flags asserted to precede the positional prompt, nothing emitted when unset
- Defaults assertions extended in all three `new/0`-`new/1` blocks

## Gates

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` (269 passed)
- [x] `mix dialyzer` (0 errors)
- [x] `mix docs`
- [x] `mix credo --strict` on six of the seven changed files -- clean, 69 checks

On that last one: passing `test/codex_wrapper/exec_test.exs` to credo crashes it locally with a `FunctionClauseError` in `Credo.Code.Token.position/1`, tripping on a `~s(web_search="#{value}")` sigil that was already in that file before this change. It is an Elixir 1.20.2 tokenizer incompatibility in credo 1.7.17, not a finding about this diff; CI's pinned Elixir 1.19 / OTP 27 runs credo over the whole tree.

## Base

Branched from `origin/main` (`9a2fdd2`). Does not stack on the six PRs already open (#73-#78). It does share `lib/codex_wrapper/exec.ex`, `exec_resume.ex`, `review.ex`, and `README.md` with #73, so whichever of the two lands second will need a rebase.
