### PR TITLE
fix: emit sandbox_mode config override on ExecResume and Review

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,16 @@ Review.new()
 ```
 
 `full_auto/1` is still available on `Exec`, `ExecResume` and `Review`,
-but it is deprecated upstream: it now emits `--sandbox workspace-write`
-rather than the deprecated `--full-auto` flag. An explicit `sandbox/2`
-call wins over it.
+but it is deprecated upstream: it now selects the `workspace-write`
+sandbox rather than emitting the deprecated `--full-auto` flag. An
+explicit `sandbox/2` call wins over it.
+
+`sandbox/2` works on all three builders but emits different arguments.
+`codex exec` takes `--sandbox <mode>`; `codex exec resume` and `codex
+exec review` reject that flag with `unexpected argument`, so on
+`ExecResume` and `Review` the builder emits the equivalent config
+override `-c sandbox_mode="<mode>"` instead. The public API and the
+three accepted modes are the same either way.
 
 ## Session resumption
 

--- a/lib/codex_wrapper/exec_resume.ex
+++ b/lib/codex_wrapper/exec_resume.ex
@@ -97,16 +97,24 @@ defmodule CodexWrapper.ExecResume do
   @spec model(t(), String.t()) :: t()
   def model(%__MODULE__{} = e, model), do: %{e | model: model}
 
-  @doc "Set the sandbox mode."
+  @doc """
+  Set the sandbox mode.
+
+  Emits `-c sandbox_mode="<mode>"` rather than `--sandbox <mode>`: the
+  flag is accepted by `codex exec` only, and `codex exec resume` rejects
+  it with `unexpected argument`. The config key is the supported
+  equivalent and takes the same three values.
+  """
   @spec sandbox(t(), sandbox_mode()) :: t()
   def sandbox(%__MODULE__{} = e, mode), do: %{e | sandbox: mode}
 
   @doc """
   Enable full-auto mode.
 
-  Deprecated upstream. Emits `--sandbox workspace-write`, which is what
-  the Codex CLI now tells you to use in place of `--full-auto`. An
-  explicit `sandbox/2` call is more specific and wins over this.
+  Deprecated upstream. Emits `-c sandbox_mode="workspace-write"`, the
+  config-key form of what the Codex CLI now tells you to use in place of
+  `--full-auto`. An explicit `sandbox/2` call is more specific and wins
+  over this.
   """
   @spec full_auto(t()) :: t()
   def full_auto(%__MODULE__{} = e), do: %{e | full_auto: true}
@@ -230,14 +238,13 @@ defmodule CodexWrapper.ExecResume do
   @impl Command
   def args(%__MODULE__{} = e) do
     ["exec", "resume"]
-    |> add_list("-c", e.config_overrides)
+    |> add_list("-c", config_overrides(e))
     |> add_list("--enable", e.enabled_features)
     |> add_list("--disable", e.disabled_features)
     |> add_bool("--last", e.last)
     |> add_bool("--all", e.all)
     |> add_list("--image", e.images)
     |> add_opt("--model", e.model)
-    |> add_opt("--sandbox", format_sandbox(effective_sandbox(e)))
     |> add_bool(
       "--dangerously-bypass-approvals-and-sandbox",
       e.dangerously_bypass_approvals_and_sandbox
@@ -279,6 +286,22 @@ defmodule CodexWrapper.ExecResume do
 
   defp port_cd_opts(%Config{working_dir: nil}), do: []
   defp port_cd_opts(%Config{working_dir: dir}), do: [{:cd, String.to_charlist(dir)}]
+
+  # `--sandbox` is an `exec`-only flag: `exec resume` rejects it outright.
+  # `sandbox_mode` is the config key the subcommand does accept, so the
+  # builder option folds into the `-c` overrides rather than dropping.
+  # User-supplied overrides come first, so an explicit `sandbox/2` call
+  # wins on a last-wins CLI.
+  defp config_overrides(%__MODULE__{} = e) do
+    e.config_overrides ++ sandbox_override(e)
+  end
+
+  defp sandbox_override(%__MODULE__{} = e) do
+    case format_sandbox(effective_sandbox(e)) do
+      nil -> []
+      mode -> [~s(sandbox_mode="#{mode}")]
+    end
+  end
 
   # `--full-auto` is deprecated upstream ("use --sandbox workspace-write"),
   # so translate it instead of emitting it. An explicit sandbox/2 call is

--- a/lib/codex_wrapper/review.ex
+++ b/lib/codex_wrapper/review.ex
@@ -104,16 +104,24 @@ defmodule CodexWrapper.Review do
   @spec model(t(), String.t()) :: t()
   def model(%__MODULE__{} = r, model), do: %{r | model: model}
 
-  @doc "Set the sandbox mode."
+  @doc """
+  Set the sandbox mode.
+
+  Emits `-c sandbox_mode="<mode>"` rather than `--sandbox <mode>`: the
+  flag is accepted by `codex exec` only, and `codex exec review` rejects
+  it with `unexpected argument`. The config key is the supported
+  equivalent and takes the same three values.
+  """
   @spec sandbox(t(), sandbox_mode()) :: t()
   def sandbox(%__MODULE__{} = r, mode), do: %{r | sandbox: mode}
 
   @doc """
   Enable full-auto mode.
 
-  Deprecated upstream. Emits `--sandbox workspace-write`, which is what
-  the Codex CLI now tells you to use in place of `--full-auto`. An
-  explicit `sandbox/2` call is more specific and wins over this.
+  Deprecated upstream. Emits `-c sandbox_mode="workspace-write"`, the
+  config-key form of what the Codex CLI now tells you to use in place of
+  `--full-auto`. An explicit `sandbox/2` call is more specific and wins
+  over this.
   """
   @spec full_auto(t()) :: t()
   def full_auto(%__MODULE__{} = r), do: %{r | full_auto: true}
@@ -233,7 +241,7 @@ defmodule CodexWrapper.Review do
   @impl Command
   def args(%__MODULE__{} = r) do
     ["exec", "review"]
-    |> add_list("-c", r.config_overrides)
+    |> add_list("-c", config_overrides(r))
     |> add_list("--enable", r.enabled_features)
     |> add_list("--disable", r.disabled_features)
     |> add_bool("--uncommitted", r.uncommitted)
@@ -241,7 +249,6 @@ defmodule CodexWrapper.Review do
     |> add_opt("--commit", r.commit)
     |> add_opt("--model", r.model)
     |> add_opt("--title", r.title)
-    |> add_opt("--sandbox", format_sandbox(effective_sandbox(r)))
     |> add_bool(
       "--dangerously-bypass-approvals-and-sandbox",
       r.dangerously_bypass_approvals_and_sandbox
@@ -282,6 +289,22 @@ defmodule CodexWrapper.Review do
 
   defp port_cd_opts(%Config{working_dir: nil}), do: []
   defp port_cd_opts(%Config{working_dir: dir}), do: [{:cd, String.to_charlist(dir)}]
+
+  # `--sandbox` is an `exec`-only flag: `exec review` rejects it outright.
+  # `sandbox_mode` is the config key the subcommand does accept, so the
+  # builder option folds into the `-c` overrides rather than dropping.
+  # User-supplied overrides come first, so an explicit `sandbox/2` call
+  # wins on a last-wins CLI.
+  defp config_overrides(%__MODULE__{} = r) do
+    r.config_overrides ++ sandbox_override(r)
+  end
+
+  defp sandbox_override(%__MODULE__{} = r) do
+    case format_sandbox(effective_sandbox(r)) do
+      nil -> []
+      mode -> [~s(sandbox_mode="#{mode}")]
+    end
+  end
 
   # `--full-auto` is deprecated upstream ("use --sandbox workspace-write"),
   # so translate it instead of emitting it. An explicit sandbox/2 call is

--- a/test/codex_wrapper/exec_resume_test.exs
+++ b/test/codex_wrapper/exec_resume_test.exs
@@ -141,10 +141,10 @@ defmodule CodexWrapper.ExecResumeTest do
       assert args == [
                "exec",
                "resume",
+               "-c",
+               ~s(sandbox_mode="workspace-write"),
                "--model",
                "gpt-5",
-               "--sandbox",
-               "workspace-write",
                "--skip-git-repo-check",
                "--json",
                "abc-123",
@@ -186,8 +186,8 @@ defmodule CodexWrapper.ExecResumeTest do
         |> ExecResume.args()
 
       refute "--full-auto" in args
-      assert "--sandbox" in args
-      assert "workspace-write" in args
+      refute "--sandbox" in args
+      assert ~s(sandbox_mode="workspace-write") in args
       assert "--dangerously-bypass-approvals-and-sandbox" in args
       assert "--last" in args
       assert "--all" in args
@@ -223,10 +223,10 @@ defmodule CodexWrapper.ExecResumeTest do
   end
 
   describe "full_auto translation" do
-    test "full_auto translates to --sandbox workspace-write" do
+    test "full_auto translates to sandbox_mode workspace-write" do
       args = ExecResume.new() |> ExecResume.full_auto() |> ExecResume.args()
-      idx = Enum.find_index(args, &(&1 == "--sandbox"))
-      assert Enum.at(args, idx + 1) == "workspace-write"
+      idx = Enum.find_index(args, &(&1 == ~s(sandbox_mode="workspace-write")))
+      assert Enum.at(args, idx - 1) == "-c"
       refute "--full-auto" in args
     end
 
@@ -237,14 +237,48 @@ defmodule CodexWrapper.ExecResumeTest do
         |> ExecResume.sandbox(:read_only)
         |> ExecResume.args()
 
-      idx = Enum.find_index(args, &(&1 == "--sandbox"))
-      assert Enum.at(args, idx + 1) == "read-only"
-      refute "workspace-write" in args
+      assert ~s(sandbox_mode="read-only") in args
+      refute ~s(sandbox_mode="workspace-write") in args
     end
 
-    test "no --sandbox when neither is set" do
+    test "no sandbox_mode override when neither is set" do
       args = ExecResume.new() |> ExecResume.args()
+      refute Enum.any?(args, &String.starts_with?(&1, "sandbox_mode="))
+    end
+  end
+
+  # `codex exec resume` rejects `--sandbox` with "unexpected argument"; the
+  # flag is accepted by `codex exec` only. See issue #80.
+  describe "sandbox mode is a -c override, never a flag" do
+    test "sandbox/2 emits -c sandbox_mode and no bare --sandbox" do
+      for {mode, formatted} <- [
+            {:read_only, "read-only"},
+            {:workspace_write, "workspace-write"},
+            {:danger_full_access, "danger-full-access"}
+          ] do
+        args = ExecResume.new() |> ExecResume.sandbox(mode) |> ExecResume.args()
+
+        refute "--sandbox" in args
+        idx = Enum.find_index(args, &(&1 == ~s(sandbox_mode="#{formatted}")))
+        assert Enum.at(args, idx - 1) == "-c"
+      end
+    end
+
+    test "full_auto/1 emits no bare --sandbox either" do
+      args = ExecResume.new() |> ExecResume.full_auto() |> ExecResume.args()
       refute "--sandbox" in args
+    end
+
+    test "user config overrides come before the derived sandbox_mode" do
+      args =
+        ExecResume.new()
+        |> ExecResume.config(~s(sandbox_mode="danger-full-access"))
+        |> ExecResume.sandbox(:read_only)
+        |> ExecResume.args()
+
+      user_idx = Enum.find_index(args, &(&1 == ~s(sandbox_mode="danger-full-access")))
+      derived_idx = Enum.find_index(args, &(&1 == ~s(sandbox_mode="read-only")))
+      assert user_idx < derived_idx
     end
   end
 end

--- a/test/codex_wrapper/review_test.exs
+++ b/test/codex_wrapper/review_test.exs
@@ -183,8 +183,8 @@ defmodule CodexWrapper.ReviewTest do
         |> Review.args()
 
       refute "--full-auto" in args
-      assert "--sandbox" in args
-      assert "workspace-write" in args
+      refute "--sandbox" in args
+      assert ~s(sandbox_mode="workspace-write") in args
       assert "--dangerously-bypass-approvals-and-sandbox" in args
       assert "--skip-git-repo-check" in args
       assert "--ephemeral" in args
@@ -238,23 +238,57 @@ defmodule CodexWrapper.ReviewTest do
   end
 
   describe "full_auto translation" do
-    test "full_auto translates to --sandbox workspace-write" do
+    test "full_auto translates to sandbox_mode workspace-write" do
       args = Review.new() |> Review.full_auto() |> Review.args()
-      idx = Enum.find_index(args, &(&1 == "--sandbox"))
-      assert Enum.at(args, idx + 1) == "workspace-write"
+      idx = Enum.find_index(args, &(&1 == ~s(sandbox_mode="workspace-write")))
+      assert Enum.at(args, idx - 1) == "-c"
       refute "--full-auto" in args
     end
 
     test "an explicit sandbox wins over full_auto" do
       args = Review.new() |> Review.full_auto() |> Review.sandbox(:read_only) |> Review.args()
-      idx = Enum.find_index(args, &(&1 == "--sandbox"))
-      assert Enum.at(args, idx + 1) == "read-only"
-      refute "workspace-write" in args
+      assert ~s(sandbox_mode="read-only") in args
+      refute ~s(sandbox_mode="workspace-write") in args
     end
 
-    test "no --sandbox when neither is set" do
+    test "no sandbox_mode override when neither is set" do
       args = Review.new() |> Review.args()
+      refute Enum.any?(args, &String.starts_with?(&1, "sandbox_mode="))
+    end
+  end
+
+  # `codex exec review` rejects `--sandbox` with "unexpected argument"; the
+  # flag is accepted by `codex exec` only. See issue #80.
+  describe "sandbox mode is a -c override, never a flag" do
+    test "sandbox/2 emits -c sandbox_mode and no bare --sandbox" do
+      for {mode, formatted} <- [
+            {:read_only, "read-only"},
+            {:workspace_write, "workspace-write"},
+            {:danger_full_access, "danger-full-access"}
+          ] do
+        args = Review.new() |> Review.sandbox(mode) |> Review.args()
+
+        refute "--sandbox" in args
+        idx = Enum.find_index(args, &(&1 == ~s(sandbox_mode="#{formatted}")))
+        assert Enum.at(args, idx - 1) == "-c"
+      end
+    end
+
+    test "full_auto/1 emits no bare --sandbox either" do
+      args = Review.new() |> Review.full_auto() |> Review.args()
       refute "--sandbox" in args
+    end
+
+    test "user config overrides come before the derived sandbox_mode" do
+      args =
+        Review.new()
+        |> Review.config(~s(sandbox_mode="danger-full-access"))
+        |> Review.sandbox(:read_only)
+        |> Review.args()
+
+      user_idx = Enum.find_index(args, &(&1 == ~s(sandbox_mode="danger-full-access")))
+      derived_idx = Enum.find_index(args, &(&1 == ~s(sandbox_mode="read-only")))
+      assert user_idx < derived_idx
     end
   end
 end


### PR DESCRIPTION
Closes #80.

## Problem

`codex exec resume` and `codex exec review` reject `--sandbox <mode>` with `unexpected argument`. The flag is accepted by `codex exec` only. Both builders emitted it, so `sandbox/2` and `full_auto/1` on those two produced a CLI parse error instead of a run.

```
$ codex exec resume --sandbox read-only
error: unexpected argument '--sandbox' found
```

## Fix

Redirect rather than remove. `sandbox_mode` is a valid `-c` config key on both subcommands and takes the same three values:

```
$ codex exec review --strict-config -c sandbox_mode="not-a-mode" "hi"
Error loading config.toml: unknown variant `not-a-mode`, expected one of `read-only`, `workspace-write`, `danger-full-access`
in `sandbox_mode`
```

`ExecResume` and `Review` now fold the selected mode into their `-c` overrides, mirroring what `approval_policy` and `web_search` already do on `Exec` (#53, #54). The public API is unchanged: `sandbox/2` and `full_auto/1` keep their signatures and semantics, only the emitted argument changes.

| Builder | Before | After |
|---|---|---|
| `Exec` | `--sandbox <mode>` | unchanged |
| `ExecResume` | `--sandbox <mode>` | `-c sandbox_mode="<mode>"` |
| `Review` | `--sandbox <mode>` | `-c sandbox_mode="<mode>"` |

`full_auto/1` still translates to `:workspace_write` and flows through the same path. User-supplied `config/2` overrides are emitted before the derived one, so the explicit `sandbox/2` call wins on a last-wins CLI.

`--dangerously-bypass-approvals-and-sandbox` is accepted by all three subcommands and is untouched.

## Tests

New `sandbox mode is a -c override, never a flag` describe block on both builders: all three modes emit `-c sandbox_mode=...`, neither builder emits a bare `--sandbox` from `sandbox/2` or `full_auto/1`, and user overrides precede the derived one. Existing arg-ordering and full_auto tests updated. `Exec`'s `--sandbox` tests are untouched and still pass.

## Verification

Probed against a real authenticated codex-cli 0.145.0 on 2026-07-26.

Local gates: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix test` (251 passed), `mix dialyzer` (0 errors), `mix docs` all pass. `mix credo --strict` on the two changed lib files reports no issues; it cannot run over the changed test files locally because credo 1.7.17 crashes on sigil tokens under Elixir 1.20, which CI (Elixir 1.19) does not hit.

## Note on conflicts

Touches `lib/codex_wrapper/exec_resume.ex`, `lib/codex_wrapper/review.ex`, and `README.md`, which open PRs #73 and #79 also touch. Whichever lands last needs a rebase.
