### PR TITLE
feat: stream NDJSON through the Runner, with a forcola-backed path

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,9 +453,11 @@ CodexWrapper.raw(["some", "new", "subcommand"])
 
 ### Runners: process-group cleanup with forcola
 
-Synchronous commands (`CodexWrapper.exec/2`, `Exec.execute/2`,
-`ExecResume.execute/2`, `Review.execute/2`) route through a runner
-module. The default, `CodexWrapper.Runner.Port`, runs `codex` under a
+Every `codex` subprocess -- the synchronous commands
+(`CodexWrapper.exec/2`, `Exec.execute/2`, `ExecResume.execute/2`,
+`Review.execute/2`) and the NDJSON streaming paths (`Exec.stream/2`,
+`ExecResume.stream/2`, `Review.stream/2`, `Session.stream/3`) -- routes
+through a runner module. The default, `CodexWrapper.Runner.Port`, runs `codex` under a
 `/bin/sh` wrapper with stdin closed and bounds it with a BEAM `Task`
 timeout. On timeout the BEAM task is killed, but no signal reaches the
 `codex` process group, so `codex` and any stdio MCP servers it spawned
@@ -497,8 +499,25 @@ the dependency stays optional and the default path is unchanged.
 config :codex_wrapper, runner: :forcola, forcola_default_timeout_ms: 120_000
 ```
 
-The streaming paths (`Exec.stream/2` and friends) still use the built-in
-`Port`; forcola-backed streaming is a planned follow-up (see #48).
+#### Streaming through a runner
+
+The streaming paths go through the same selection, so `:forcola` gets
+their process group killed too -- on an early `Enum.take/2`, on a
+timeout, or when the BEAM dies.
+
+The two runners enforce a command's `:timeout` differently for a stream.
+`Runner.Port` treats it as an *idle* bound (the wait for the next line,
+what the streaming paths have always used, defaulting to `300_000` when
+`:timeout` is `nil`). `Runner.Forcola` treats it as forcola's whole-run
+bound, falling back to `:forcola_default_timeout_ms` the same way the
+synchronous path does.
+
+A non-zero exit ends a stream without raising on either runner -- the
+`Enumerable` simply finishes. Use `execute/2` when the exit code matters.
+
+A custom runner only has to implement `run/4`; `stream_lines/4` is
+optional, and a runner without it falls back to `Runner.Port` for
+streams.
 
 ### Exec options
 
@@ -539,7 +558,7 @@ The streaming paths (`Exec.stream/2` and friends) still use the built-in
 | `CodexWrapper.Retry` | Exponential backoff retry |
 | `CodexWrapper.IEx` | Interactive REPL helpers |
 | `CodexWrapper.Command` | Behaviour for CLI commands |
-| `CodexWrapper.Runner` | Behaviour selecting how one-shot subprocesses execute |
+| `CodexWrapper.Runner` | Behaviour selecting how subprocesses execute and stream |
 | `CodexWrapper.Runner.Port` | Default runner (`/bin/sh` Port with closed stdin) |
 | `CodexWrapper.Runner.Forcola` | Optional leak-free runner via `forcola` |
 | `CodexWrapper.Commands.Auth` | Authentication (login/logout/status) |

--- a/lib/codex_wrapper/config.ex
+++ b/lib/codex_wrapper/config.ex
@@ -82,4 +82,19 @@ defmodule CodexWrapper.Config do
     opts = if config.env != [], do: [{:env, config.env} | opts], else: opts
     opts
   end
+
+  @doc """
+  Build the runner options for a streaming run.
+
+  Same shape as `cmd_opts/1` but with `stderr_to_stdout: false`: the
+  streaming paths parse NDJSON off stdout, and merging stderr into it
+  would put unparseable lines in the stream. Stderr is left to flow to
+  the parent's stderr.
+  """
+  @spec stream_opts(t()) :: keyword()
+  def stream_opts(%__MODULE__{} = config) do
+    config
+    |> cmd_opts()
+    |> Keyword.put(:stderr_to_stdout, false)
+  end
 end

--- a/lib/codex_wrapper/exec.ex
+++ b/lib/codex_wrapper/exec.ex
@@ -20,7 +20,7 @@ defmodule CodexWrapper.Exec do
 
   @behaviour CodexWrapper.Command
 
-  alias CodexWrapper.{Command, Config, JsonLineEvent, Result}
+  alias CodexWrapper.{Command, Config, JsonLineEvent, Result, Runner}
 
   @type sandbox_mode :: :read_only | :workspace_write | :danger_full_access
   @type approval_policy :: :untrusted | :on_request | :never
@@ -295,9 +295,10 @@ defmodule CodexWrapper.Exec do
   @doc """
   Execute the command and return a lazy `Stream` of `%JsonLineEvent{}`.
 
-  Uses a Port with `:line` mode to read NDJSON output line-by-line.
-  The port is opened when the stream is consumed and closed when
-  the stream terminates.
+  Reads NDJSON output line-by-line through the configured
+  `CodexWrapper.Runner`. The process starts when the stream is consumed
+  and is terminated when the stream halts. Lines that do not parse as
+  JSON are skipped.
 
   Forces `--json` on the exec command.
   """
@@ -305,44 +306,10 @@ defmodule CodexWrapper.Exec do
   def stream(%__MODULE__{} = exec, %Config{} = config) do
     exec = %{exec | json: true}
     args = Config.base_args(config) ++ args(exec)
-    shell_args = Command.shell_cmd_args(config.binary, args)
 
-    port_opts =
-      [:binary, :exit_status, {:line, 1_048_576}, {:args, shell_args}] ++
-        port_env_opts(config) ++
-        port_cd_opts(config)
-
-    Stream.resource(
-      fn ->
-        Port.open({:spawn_executable, "/bin/sh"}, port_opts)
-      end,
-      fn port ->
-        receive do
-          {^port, {:data, {:eol, line}}} ->
-            case JsonLineEvent.parse(line) do
-              {:ok, event} -> {[event], port}
-              {:error, _} -> {[], port}
-            end
-
-          {^port, {:data, {:noeol, _partial}}} ->
-            {[], port}
-
-          {^port, {:exit_status, _code}} ->
-            {:halt, port}
-        after
-          300_000 -> {:halt, port}
-        end
-      end,
-      fn port ->
-        send(port, {self(), :close})
-
-        receive do
-          {^port, :closed} -> :ok
-        after
-          5_000 -> :ok
-        end
-      end
-    )
+    config.binary
+    |> Runner.stream_lines(args, Config.stream_opts(config), config.timeout)
+    |> JsonLineEvent.parse_stream()
   end
 
   # --- Command behaviour ---
@@ -445,10 +412,4 @@ defmodule CodexWrapper.Exec do
   defp format_approval_policy(:never), do: "never"
 
   # --- Port helpers ---
-
-  defp port_env_opts(%Config{env: []}), do: []
-  defp port_env_opts(%Config{env: env}), do: [{:env, env}]
-
-  defp port_cd_opts(%Config{working_dir: nil}), do: []
-  defp port_cd_opts(%Config{working_dir: dir}), do: [{:cd, String.to_charlist(dir)}]
 end

--- a/lib/codex_wrapper/exec_resume.ex
+++ b/lib/codex_wrapper/exec_resume.ex
@@ -25,7 +25,7 @@ defmodule CodexWrapper.ExecResume do
 
   @behaviour CodexWrapper.Command
 
-  alias CodexWrapper.{Command, Config, JsonLineEvent, Result}
+  alias CodexWrapper.{Command, Config, JsonLineEvent, Result, Runner}
 
   @type sandbox_mode :: :read_only | :workspace_write | :danger_full_access
 
@@ -229,50 +229,17 @@ defmodule CodexWrapper.ExecResume do
   @doc """
   Execute the command and return a lazy `Stream` of `%JsonLineEvent{}`.
 
-  Forces `--json` on the command. Uses a Port with `:line` mode.
+  Reads NDJSON output line-by-line through the configured
+  `CodexWrapper.Runner`. Forces `--json` on the command.
   """
   @spec stream(t(), Config.t()) :: Enumerable.t()
   def stream(%__MODULE__{} = exec, %Config{} = config) do
     exec = %{exec | json: true}
     args = Config.base_args(config) ++ args(exec)
-    shell_args = Command.shell_cmd_args(config.binary, args)
 
-    port_opts =
-      [:binary, :exit_status, {:line, 1_048_576}, {:args, shell_args}] ++
-        port_env_opts(config) ++
-        port_cd_opts(config)
-
-    Stream.resource(
-      fn ->
-        Port.open({:spawn_executable, "/bin/sh"}, port_opts)
-      end,
-      fn port ->
-        receive do
-          {^port, {:data, {:eol, line}}} ->
-            case JsonLineEvent.parse(line) do
-              {:ok, event} -> {[event], port}
-              {:error, _} -> {[], port}
-            end
-
-          {^port, {:data, {:noeol, _partial}}} ->
-            {[], port}
-
-          {^port, {:exit_status, _code}} ->
-            {:halt, port}
-        after
-          300_000 -> {:halt, port}
-        end
-      end,
-      fn port ->
-        send(port, {self(), :close})
-
-        receive do
-          {^port, :closed} -> :ok
-        after
-          5_000 -> :ok
-        end
-      end
-    )
+    config.binary
+    |> Runner.stream_lines(args, Config.stream_opts(config), config.timeout)
+    |> JsonLineEvent.parse_stream()
   end
 
   # --- Command behaviour ---
@@ -326,12 +293,6 @@ defmodule CodexWrapper.ExecResume do
   defp add_list(args, flag, values), do: args ++ Enum.flat_map(values, &[flag, &1])
 
   # --- Port helpers ---
-
-  defp port_env_opts(%Config{env: []}), do: []
-  defp port_env_opts(%Config{env: env}), do: [{:env, env}]
-
-  defp port_cd_opts(%Config{working_dir: nil}), do: []
-  defp port_cd_opts(%Config{working_dir: dir}), do: [{:cd, String.to_charlist(dir)}]
 
   # `--sandbox` is an `exec`-only flag: `exec resume` rejects it outright.
   # `sandbox_mode` is the config key the subcommand does accept, so the

--- a/lib/codex_wrapper/json_line_event.ex
+++ b/lib/codex_wrapper/json_line_event.ex
@@ -64,6 +64,24 @@ defmodule CodexWrapper.JsonLineEvent do
   end
 
   @doc """
+  Parse a lazy stream of NDJSON lines into a lazy stream of events.
+
+  The streaming counterpart of `parse_lines/1`: same silent drop of
+  lines that do not parse, no buffering of the whole run. Used by
+  `Exec.stream/2`, `ExecResume.stream/2`, and `Review.stream/2` over the
+  lines their `CodexWrapper.Runner` produces.
+  """
+  @spec parse_stream(Enumerable.t()) :: Enumerable.t()
+  def parse_stream(lines) do
+    Stream.flat_map(lines, fn line ->
+      case parse(line) do
+        {:ok, event} -> [event]
+        {:error, _} -> []
+      end
+    end)
+  end
+
+  @doc """
   Return the event type string.
   """
   @spec event_type(t()) :: String.t() | nil

--- a/lib/codex_wrapper/review.ex
+++ b/lib/codex_wrapper/review.ex
@@ -28,7 +28,7 @@ defmodule CodexWrapper.Review do
 
   @behaviour CodexWrapper.Command
 
-  alias CodexWrapper.{Command, Config, JsonLineEvent, Result}
+  alias CodexWrapper.{Command, Config, JsonLineEvent, Result, Runner}
 
   @type sandbox_mode :: :read_only | :workspace_write | :danger_full_access
 
@@ -232,50 +232,17 @@ defmodule CodexWrapper.Review do
   @doc """
   Execute the review command and return a lazy `Stream` of `%JsonLineEvent{}`.
 
-  Uses a Port with `:line` mode to read NDJSON output line-by-line.
-  Forces `--json` on the command.
+  Reads NDJSON output line-by-line through the configured
+  `CodexWrapper.Runner`. Forces `--json` on the command.
   """
   @spec stream(t(), Config.t()) :: Enumerable.t()
   def stream(%__MODULE__{} = review, %Config{} = config) do
     review = %{review | json: true}
     args = Config.base_args(config) ++ args(review)
 
-    port_opts =
-      [:binary, :exit_status, {:line, 1_048_576}, {:args, args}] ++
-        port_env_opts(config) ++
-        port_cd_opts(config)
-
-    Stream.resource(
-      fn ->
-        Port.open({:spawn_executable, config.binary}, port_opts)
-      end,
-      fn port ->
-        receive do
-          {^port, {:data, {:eol, line}}} ->
-            case JsonLineEvent.parse(line) do
-              {:ok, event} -> {[event], port}
-              {:error, _} -> {[], port}
-            end
-
-          {^port, {:data, {:noeol, _partial}}} ->
-            {[], port}
-
-          {^port, {:exit_status, _code}} ->
-            {:halt, port}
-        after
-          300_000 -> {:halt, port}
-        end
-      end,
-      fn port ->
-        send(port, {self(), :close})
-
-        receive do
-          {^port, :closed} -> :ok
-        after
-          5_000 -> :ok
-        end
-      end
-    )
+    config.binary
+    |> Runner.stream_lines(args, Config.stream_opts(config), config.timeout)
+    |> JsonLineEvent.parse_stream()
   end
 
   # --- Command behaviour ---
@@ -329,12 +296,6 @@ defmodule CodexWrapper.Review do
   defp add_list(args, flag, values), do: args ++ Enum.flat_map(values, &[flag, &1])
 
   # --- Port helpers ---
-
-  defp port_env_opts(%Config{env: []}), do: []
-  defp port_env_opts(%Config{env: env}), do: [{:env, env}]
-
-  defp port_cd_opts(%Config{working_dir: nil}), do: []
-  defp port_cd_opts(%Config{working_dir: dir}), do: [{:cd, String.to_charlist(dir)}]
 
   # `--sandbox` is an `exec`-only flag: `exec review` rejects it outright.
   # `sandbox_mode` is the config key the subcommand does accept, so the

--- a/lib/codex_wrapper/runner.ex
+++ b/lib/codex_wrapper/runner.ex
@@ -28,6 +28,16 @@ defmodule CodexWrapper.Runner do
   exit is *not* an error -- callers decide what an exit code means),
   `{:error, :timeout}` when the timeout elapsed, and other `{:error,
   reason}` tuples for spawn/signal/io failures.
+
+  `stream_lines/4` returns a lazy `Enumerable` of stdout lines for the
+  NDJSON paths (`Exec.stream/2`, `ExecResume.stream/2`, `Review.stream/2`,
+  and `Session.stream/3` through the first two). Lines arrive without
+  their trailing newline, stderr is never merged into them, and the
+  stream ends when the process exits.
+
+  A non-zero exit ends the stream *without* raising, on either runner --
+  the same silent-halt the streaming paths have always had. Callers that
+  need the exit code should use `execute/2` rather than `stream/2`.
   """
 
   @typedoc "Runner error reasons. `:timeout` is common to every runner."
@@ -54,6 +64,29 @@ defmodule CodexWrapper.Runner do
             ) :: {:ok, {String.t(), non_neg_integer()}} | {:error, error()}
 
   @doc """
+  Run `binary` with `args` and stream its stdout as lines.
+
+  Returns a lazy `Enumerable` of lines without their trailing newlines.
+  Opening the process is deferred until the stream is consumed, and the
+  process is terminated when the stream halts (including an early
+  `Enum.take/2`).
+
+  `timeout` is enforced as each runner can: `Runner.Port` applies it as
+  an idle bound between output frames (what the streaming paths have
+  always done), `Runner.Forcola` as forcola's whole-run bound with a
+  process-group kill. `nil` means each runner's own default.
+
+  Optional. `CodexWrapper.Runner.stream_lines/4` falls back to
+  `Runner.Port` for runners that do not implement it.
+  """
+  @callback stream_lines(
+              binary :: String.t(),
+              args :: [String.t()],
+              opts :: opts(),
+              timeout :: timeout() | nil
+            ) :: Enumerable.t()
+
+  @doc """
   The timeout the runner will actually enforce for a caller's `timeout`.
 
   Callers pass `nil` for "no timeout", but a runner may substitute a bound
@@ -63,7 +96,7 @@ defmodule CodexWrapper.Runner do
   """
   @callback effective_timeout(timeout :: timeout() | nil) :: timeout() | nil
 
-  @optional_callbacks effective_timeout: 1
+  @optional_callbacks effective_timeout: 1, stream_lines: 4
 
   @doc """
   The configured runner module, `CodexWrapper.Runner.Port` by default.
@@ -109,5 +142,24 @@ defmodule CodexWrapper.Runner do
     else
       timeout
     end
+  end
+
+  @doc """
+  `stream_lines/4` on the configured runner.
+
+  Falls back to `CodexWrapper.Runner.Port` when the configured runner
+  does not implement the optional callback, so a runner written against
+  the one-shot `run/4` contract alone keeps working.
+  """
+  @spec stream_lines(String.t(), [String.t()], opts(), timeout() | nil) :: Enumerable.t()
+  def stream_lines(binary, args, opts, timeout) do
+    runner = impl()
+
+    runner =
+      if function_exported?(runner, :stream_lines, 4),
+        do: runner,
+        else: CodexWrapper.Runner.Port
+
+    runner.stream_lines(binary, args, opts, timeout)
   end
 end

--- a/lib/codex_wrapper/runner/forcola.ex
+++ b/lib/codex_wrapper/runner/forcola.ex
@@ -18,6 +18,13 @@ if Code.ensure_loaded?(Forcola) do
     `:timeout` runs under `forcola_default_timeout_ms` instead of
     unbounded. See `effective_timeout/1`.
 
+    `stream_lines/4` is backed by `Forcola.Stream.lines/2`, so the
+    NDJSON paths (`Exec.stream/2` and friends) get the same group kill
+    on halt, timeout, or BEAM death. Unlike `Forcola.Stream.lines/2`,
+    it does not raise on a non-zero exit -- it ends the stream, which is
+    what `CodexWrapper.Runner.Port` has always done and what the
+    `CodexWrapper.Runner` contract specifies.
+
     This module compiles only when `forcola` is a dependency. Select it
     with `config :codex_wrapper, runner: CodexWrapper.Runner.Forcola`
     (or the `:forcola` shorthand). forcola is POSIX-only.
@@ -63,6 +70,55 @@ if Code.ensure_loaded?(Forcola) do
         {:error, {:spawn, reason}} ->
           {:error, {:spawn, reason}}
       end
+    end
+
+    @impl true
+    def stream_lines(binary, args, opts, timeout) do
+      stream_opts =
+        [timeout_ms: effective_timeout(timeout), merge_stderr: merge_stderr?(opts)] ++
+          Keyword.take(opts, [:cd, :env])
+
+      [binary | args]
+      |> Forcola.Stream.lines(stream_opts)
+      |> halt_on_error()
+    end
+
+    # `Forcola.Stream.lines/2` raises on a non-zero exit, a signal, a
+    # timeout, or a spawn failure. The wrapper's streaming contract ends
+    # the stream instead (see `CodexWrapper.Runner`), so translate.
+    # forcola has already killed the process group by the time it raises,
+    # so there is nothing left to clean up.
+    defp halt_on_error(enum) do
+      Stream.resource(
+        fn -> &Enumerable.reduce(enum, &1, fn line, _acc -> {:suspend, line} end) end,
+        &pull/1,
+        fn
+          :done -> :ok
+          cont -> halt_continuation(cont)
+        end
+      )
+    end
+
+    defp pull(:done), do: {:halt, :done}
+
+    defp pull(cont) do
+      case cont.({:cont, nil}) do
+        {:suspended, line, next} -> {[line], next}
+        {:done, _acc} -> {:halt, :done}
+        {:halted, _acc} -> {:halt, :done}
+      end
+    rescue
+      Forcola.Stream.Error -> {:halt, :done}
+    end
+
+    # Halting the suspended reduction is what kills the process group on an
+    # early `Enum.take/2`. It runs forcola's own cleanup, which raises for
+    # the same reasons `pull/1` guards against.
+    defp halt_continuation(cont) do
+      cont.({:halt, nil})
+      :ok
+    rescue
+      Forcola.Stream.Error -> :ok
     end
 
     defp merge_stderr?(opts), do: Keyword.get(opts, :stderr_to_stdout, false)

--- a/lib/codex_wrapper/runner/port.ex
+++ b/lib/codex_wrapper/runner/port.ex
@@ -10,11 +10,25 @@ defmodule CodexWrapper.Runner.Port do
   servers, tool helpers) may keep running until they next touch a closed
   pipe. For strict termination, use `CodexWrapper.Runner.Forcola` (see
   `CodexWrapper.Runner` and #48).
+
+  `stream_lines/4` uses the same `/bin/sh` wrapper in `:line` mode, and
+  treats `timeout` as an *idle* bound: the wait for the next line, not
+  for the whole run. That is what the streaming paths have always done.
   """
 
   @behaviour CodexWrapper.Runner
 
   alias CodexWrapper.Command
+
+  # Idle bound between output frames when the caller sets no timeout.
+  @default_idle_timeout_ms 300_000
+
+  # How long to wait for the port to confirm it closed when the stream halts.
+  @close_timeout_ms 5_000
+
+  # A line longer than this is split across frames; the fragments are
+  # dropped, matching the pre-Runner streaming paths.
+  @max_line_bytes 1_048_576
 
   @impl true
   def run(binary, args, opts, timeout) do
@@ -24,6 +38,66 @@ defmodule CodexWrapper.Runner.Port do
     case Task.yield(task, effective_timeout) || Task.shutdown(task, :brutal_kill) do
       {:ok, {stdout, code}} -> {:ok, {stdout, code}}
       nil -> {:error, :timeout}
+    end
+  end
+
+  @impl true
+  def stream_lines(binary, args, opts, timeout) do
+    idle_timeout = timeout || @default_idle_timeout_ms
+
+    port_opts =
+      [
+        :binary,
+        :exit_status,
+        {:line, @max_line_bytes},
+        {:args, Command.shell_cmd_args(binary, args)}
+      ]
+      |> maybe_add(:cd, stream_cd(opts))
+      |> maybe_add_env(Keyword.get(opts, :env, []))
+
+    Stream.resource(
+      fn -> {Port.open({:spawn_executable, "/bin/sh"}, port_opts), :running} end,
+      fn state -> next_line(state, idle_timeout) end,
+      &close_port/1
+    )
+  end
+
+  defp next_line({port, :running} = state, idle_timeout) do
+    receive do
+      {^port, {:data, {:eol, line}}} -> {[line], state}
+      {^port, {:data, {:noeol, _partial}}} -> {[], state}
+      {^port, {:exit_status, _code}} -> {:halt, {port, :exited}}
+    after
+      idle_timeout -> {:halt, state}
+    end
+  end
+
+  # The process exited on its own, so the port is already gone. Asking it
+  # to close would just block until `@close_timeout_ms` for a `:closed`
+  # that can never arrive.
+  defp close_port({_port, :exited}), do: :ok
+
+  # Halted early (`Enum.take/2`, an idle timeout, an exception downstream)
+  # with the process still alive: close the port, which closes its stdout
+  # and leaves `codex` to die when it next writes. Use
+  # `CodexWrapper.Runner.Forcola` if you need the group killed outright.
+  defp close_port({port, :running}) do
+    send(port, {self(), :close})
+
+    receive do
+      {^port, :closed} -> :ok
+    after
+      @close_timeout_ms -> :ok
+    end
+  end
+
+  # `Config.cmd_opts/1` hands `:cd` over as a string; `Port.open/2` has
+  # always been given a charlist on the streaming paths.
+  defp stream_cd(opts) do
+    case Keyword.get(opts, :cd) do
+      nil -> nil
+      dir when is_binary(dir) -> String.to_charlist(dir)
+      dir -> dir
     end
   end
 

--- a/test/codex_wrapper/runner/forcola_test.exs
+++ b/test/codex_wrapper/runner/forcola_test.exs
@@ -57,4 +57,60 @@ defmodule CodexWrapper.Runner.ForcolaTest do
       refute os_alive?(pid), "expected pid #{pid} to be killed on timeout, but it is alive"
     end
   end
+
+  describe "stream_lines/4" do
+    test "emits one element per line, without trailing newlines" do
+      assert ["a", "b", "c"] =
+               Forcola.stream_lines("printf", ["a\nb\nc\n"], [], 5_000) |> Enum.to_list()
+    end
+
+    test "does not merge stderr into the line stream" do
+      lines =
+        Forcola.stream_lines("sh", ["-c", "echo out; echo err 1>&2"], [], 5_000)
+        |> Enum.to_list()
+
+      assert lines == ["out"]
+    end
+
+    test "a non-zero exit ends the stream rather than raising" do
+      # Forcola.Stream.lines/2 raises here; the Runner contract is a clean
+      # halt, matching Runner.Port.
+      assert ["one"] =
+               Forcola.stream_lines("sh", ["-c", "echo one; exit 3"], [], 5_000)
+               |> Enum.to_list()
+    end
+
+    test "a timeout ends the stream rather than raising" do
+      script = "echo first; sleep 10; echo never"
+
+      assert ["first"] =
+               Forcola.stream_lines("sh", ["-c", script], [], 500) |> Enum.to_list()
+    end
+
+    test "a missing binary yields an empty stream rather than raising" do
+      assert [] =
+               Forcola.stream_lines("definitely-not-a-real-binary-xyz", [], [], 5_000)
+               |> Enum.to_list()
+    end
+
+    test "an early halt does not raise" do
+      assert ["y", "y"] = Forcola.stream_lines("yes", [], [], 5_000) |> Enum.take(2)
+    end
+
+    @tag :forcola_kill
+    test "an early halt kills the child's process group" do
+      pidfile =
+        Path.join(System.tmp_dir!(), "cxw_forcola_s_#{System.unique_integer([:positive])}")
+
+      on_exit(fn -> File.rm(pidfile) end)
+
+      # One line, then a sleep well past what the consumer waits for.
+      script = "echo $$ > #{pidfile}; echo line; sleep 30"
+
+      assert ["line"] = Forcola.stream_lines("sh", ["-c", script], [], 30_000) |> Enum.take(1)
+
+      pid = pidfile |> File.read!() |> String.trim()
+      refute os_alive?(pid), "expected pid #{pid} to be killed on halt, but it is alive"
+    end
+  end
 end

--- a/test/codex_wrapper/runner_test.exs
+++ b/test/codex_wrapper/runner_test.exs
@@ -38,4 +38,116 @@ defmodule CodexWrapper.RunnerTest do
       assert {:error, :timeout} = Port.run("sleep", ["10"], [], 200)
     end
   end
+
+  describe "Runner.Port.stream_lines/4" do
+    alias CodexWrapper.Runner.Port
+
+    test "emits one element per line, without trailing newlines" do
+      assert ["a", "b", "c"] =
+               Port.stream_lines("printf", ["a\\nb\\nc\\n"], [], 5_000) |> Enum.to_list()
+    end
+
+    test "does not merge stderr into the line stream" do
+      lines =
+        Port.stream_lines("sh", ["-c", "echo out; echo err 1>&2"], [], 5_000) |> Enum.to_list()
+
+      assert lines == ["out"]
+    end
+
+    test "a non-zero exit ends the stream rather than raising" do
+      assert ["one"] =
+               Port.stream_lines("sh", ["-c", "echo one; exit 3"], [], 5_000) |> Enum.to_list()
+    end
+
+    test "runs in :cd, which cmd_opts/1 hands over as a string" do
+      # `Config.cmd_opts/1` yields `:cd` as a string; the port paths have
+      # always passed Port.open/2 a charlist. Regression against handing
+      # the string straight through.
+      leaf = "cxw_stream_cd_#{System.unique_integer([:positive])}"
+      dir = Path.join(System.tmp_dir!(), leaf)
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf(dir) end)
+
+      assert [pwd] = Port.stream_lines("pwd", [], [cd: dir], 5_000) |> Enum.to_list()
+      assert Path.basename(pwd) == leaf
+    end
+
+    test "passes :env through" do
+      assert ["from-env"] =
+               Port.stream_lines(
+                 "sh",
+                 ["-c", "echo $CXW_STREAM_TEST"],
+                 [env: [{~c"CXW_STREAM_TEST", ~c"from-env"}]],
+                 5_000
+               )
+               |> Enum.to_list()
+    end
+
+    test "an early halt terminates the stream without waiting for the process" do
+      # `yes` never exits on its own, so this only returns if halting the
+      # stream closes the port.
+      assert ["y", "y"] = Port.stream_lines("yes", [], [], 5_000) |> Enum.take(2)
+    end
+
+    test "the timeout is an idle bound between lines, not a whole-run bound" do
+      # Three lines 150ms apart is 450ms of runtime under a 400ms bound:
+      # a whole-run bound would truncate it, an idle bound does not.
+      script = "for i in 1 2 3; do echo $i; sleep 0.15; done"
+
+      assert ["1", "2", "3"] =
+               Port.stream_lines("sh", ["-c", script], [], 400) |> Enum.to_list()
+    end
+
+    test "an idle producer is cut off at the timeout" do
+      script = "echo first; sleep 10; echo never"
+
+      assert ["first"] = Port.stream_lines("sh", ["-c", script], [], 300) |> Enum.to_list()
+    end
+
+    test "a completed stream returns promptly, without a close handshake" do
+      {micros, _lines} =
+        :timer.tc(fn -> Port.stream_lines("echo", ["hi"], [], 5_000) |> Enum.to_list() end)
+
+      # The port is already gone once :exit_status arrives, so asking it to
+      # close would block for the full 5s close timeout.
+      assert micros < 2_000_000
+    end
+  end
+
+  describe "stream_lines/4 dispatch" do
+    test "routes to the configured runner" do
+      Application.put_env(:codex_wrapper, :runner, CodexWrapper.RunnerTest.RecordingRunner)
+      on_exit(fn -> Application.delete_env(:codex_wrapper, :runner) end)
+
+      assert ["recorded: echo hi"] =
+               Runner.stream_lines("echo", ["hi"], [], nil) |> Enum.to_list()
+    end
+
+    test "falls back to Runner.Port when the runner has no stream_lines/4" do
+      Application.put_env(:codex_wrapper, :runner, CodexWrapper.RunnerTest.OneShotOnlyRunner)
+      on_exit(fn -> Application.delete_env(:codex_wrapper, :runner) end)
+
+      assert ["hi"] = Runner.stream_lines("echo", ["hi"], [], 5_000) |> Enum.to_list()
+    end
+  end
+
+  defmodule RecordingRunner do
+    @moduledoc false
+    @behaviour CodexWrapper.Runner
+
+    @impl true
+    def run(_binary, _args, _opts, _timeout), do: {:ok, {"", 0}}
+
+    @impl true
+    def stream_lines(binary, args, _opts, _timeout),
+      do: ["recorded: #{Enum.join([binary | args], " ")}"]
+  end
+
+  defmodule OneShotOnlyRunner do
+    @moduledoc false
+    @behaviour CodexWrapper.Runner
+
+    @impl true
+    def run(_binary, _args, _opts, _timeout), do: {:ok, {"", 0}}
+  end
 end

--- a/test/codex_wrapper/stream_routing_test.exs
+++ b/test/codex_wrapper/stream_routing_test.exs
@@ -1,0 +1,163 @@
+defmodule CodexWrapper.StreamRoutingTest do
+  @moduledoc """
+  The four `stream/*` call sites go through `CodexWrapper.Runner`.
+
+  A scripted runner stands in for the CLI, so what each builder hands the
+  runner (binary, argv, opts, timeout) is observable without the real
+  binary, the way `binary: "echo"` makes the execute paths observable.
+  """
+
+  # Not async: these override the :runner application env.
+  use ExUnit.Case, async: false
+
+  alias CodexWrapper.{Config, Exec, ExecResume, JsonLineEvent, Review, Session}
+
+  defmodule ScriptedRunner do
+    @moduledoc false
+    @behaviour CodexWrapper.Runner
+
+    @impl true
+    def run(_binary, _args, _opts, _timeout), do: {:ok, {"", 0}}
+
+    @impl true
+    def stream_lines(binary, args, opts, timeout) do
+      {pid, lines} = Application.fetch_env!(:codex_wrapper, :scripted_runner)
+      send(pid, {:stream_lines, binary, args, opts, timeout})
+
+      # Reporting each pull makes the laziness of the parse pipeline
+      # observable: a halted consumer should not drain the runner.
+      Stream.each(lines, fn line -> send(pid, {:pulled, line}) end)
+    end
+  end
+
+  setup context do
+    lines = Map.get(context, :lines, [~s({"type":"thread.started","thread_id":"t-1"})])
+
+    Application.put_env(:codex_wrapper, :runner, ScriptedRunner)
+    Application.put_env(:codex_wrapper, :scripted_runner, {self(), lines})
+
+    on_exit(fn ->
+      Application.delete_env(:codex_wrapper, :runner)
+      Application.delete_env(:codex_wrapper, :scripted_runner)
+    end)
+
+    :ok
+  end
+
+  defp config(opts \\ []), do: Config.new(Keyword.merge([binary: "codex"], opts))
+
+  describe "Exec.stream/2" do
+    test "routes through the runner with --json forced" do
+      events = "hello" |> Exec.new() |> Exec.stream(config()) |> Enum.to_list()
+
+      assert_received {:stream_lines, "codex", args, _opts, _timeout}
+      assert "exec" in args
+      assert "--json" in args
+      assert "hello" in args
+
+      assert [%JsonLineEvent{event_type: "thread.started"}] = events
+    end
+
+    test "passes the config timeout and stream opts to the runner" do
+      "hello" |> Exec.new() |> Exec.stream(config(timeout: 1_234)) |> Enum.to_list()
+
+      assert_received {:stream_lines, "codex", _args, opts, 1_234}
+
+      # Streaming parses NDJSON off stdout; merging stderr into it would
+      # put unparseable lines in the stream.
+      assert opts[:stderr_to_stdout] == false
+    end
+
+    test "honors the configured binary" do
+      "hello" |> Exec.new() |> Exec.stream(config(binary: "/opt/codex")) |> Enum.to_list()
+
+      assert_received {:stream_lines, "/opt/codex", _args, _opts, _timeout}
+    end
+
+    @tag lines: [
+           ~s({"type":"thread.started"}),
+           "not json at all",
+           ~s({"type":"item.completed"})
+         ]
+    test "drops lines that do not parse as JSON" do
+      events = "hello" |> Exec.new() |> Exec.stream(config()) |> Enum.to_list()
+
+      assert ["thread.started", "item.completed"] = Enum.map(events, & &1.event_type)
+    end
+
+    @tag lines: [
+           ~s({"type":"item.1"}),
+           ~s({"type":"item.2"}),
+           ~s({"type":"item.3"})
+         ]
+    test "stays lazy -- an early halt does not drain the runner" do
+      events = "hello" |> Exec.new() |> Exec.stream(config()) |> Enum.take(1)
+
+      assert [%JsonLineEvent{event_type: "item.1"}] = events
+
+      assert_received {:pulled, ~s({"type":"item.1"})}
+      refute_received {:pulled, ~s({"type":"item.3"})}
+    end
+  end
+
+  describe "ExecResume.stream/2" do
+    test "routes through the runner with --json forced" do
+      events =
+        ExecResume.new()
+        |> ExecResume.session_id("sid-1")
+        |> ExecResume.prompt("more")
+        |> ExecResume.stream(config())
+        |> Enum.to_list()
+
+      assert_received {:stream_lines, "codex", args, opts, _timeout}
+      assert ["exec", "resume" | _] = args
+      assert "--json" in args
+      assert opts[:stderr_to_stdout] == false
+
+      assert [%JsonLineEvent{event_type: "thread.started"}] = events
+    end
+  end
+
+  describe "Review.stream/2" do
+    test "routes through the runner with --json forced" do
+      events =
+        Review.new()
+        |> Review.uncommitted()
+        |> Review.stream(config())
+        |> Enum.to_list()
+
+      # Before the Runner refactor this path opened the binary directly,
+      # so it never got the stdin-closing wrapper the other two had.
+      assert_received {:stream_lines, "codex", args, opts, _timeout}
+      assert ["exec", "review" | _] = args
+      assert "--json" in args
+      assert opts[:stderr_to_stdout] == false
+
+      assert [%JsonLineEvent{event_type: "thread.started"}] = events
+    end
+  end
+
+  describe "Session.stream/3" do
+    test "a session with no id streams through the exec path" do
+      session = Session.new(config())
+
+      assert {^session, stream} = Session.stream(session, "hello")
+      assert [%JsonLineEvent{}] = Enum.to_list(stream)
+
+      assert_received {:stream_lines, "codex", args, _opts, _timeout}
+      assert ["exec" | rest] = args
+      refute "resume" in rest
+    end
+
+    test "a session with an id streams through the resume path" do
+      session = %{Session.new(config()) | session_id: "sid-1"}
+
+      assert {^session, stream} = Session.stream(session, "more")
+      assert [%JsonLineEvent{}] = Enum.to_list(stream)
+
+      assert_received {:stream_lines, "codex", args, _opts, _timeout}
+      assert ["exec", "resume" | _] = args
+      assert "sid-1" in args
+    end
+  end
+end


### PR DESCRIPTION
Closes the streaming half of #48.

## Problem

PR #49 routed one-shot execution through `CodexWrapper.Runner` and scoped itself there, leaving the four `stream/*` call sites on their own inlined `Port` blocks. Three near-identical copies of a `Stream.resource` sat in `exec.ex`, `exec_resume.ex`, and `review.ex`, and `config :codex_wrapper, runner: :forcola` had no effect on any of them.

## Change

`CodexWrapper.Runner` gains an optional `stream_lines/4` callback returning a lazy `Enumerable` of stdout lines, plus a `Runner.stream_lines/4` dispatcher that falls back to `Runner.Port` for runners that do not implement it. A custom runner written against `run/4` alone keeps working.

| Runner | `stream_lines/4` |
|---|---|
| `Runner.Port` | the same `/bin/sh` line-mode `Port` the streaming paths already used |
| `Runner.Forcola` | `Forcola.Stream.lines/2`, so the process group is killed on halt, timeout, or BEAM death |

The three builders now build args and hand off:

```elixir
config.binary
|> Runner.stream_lines(args, Config.stream_opts(config), config.timeout)
|> JsonLineEvent.parse_stream()
```

- `JsonLineEvent.parse_stream/1`: the lazy counterpart of `parse_lines/1`, same silent drop of lines that do not parse.
- `Config.stream_opts/1`: `cmd_opts/1` with `stderr_to_stdout: false`, so stderr cannot contaminate the NDJSON on stdout.
- `Session.stream/3` inherits all of this by delegating to `Exec.stream/2` and `ExecResume.stream/2`; it is unchanged.
- The three copies of `port_env_opts/1` and `port_cd_opts/1` are gone.

## Three behavior fixes that fall out of the consolidation

**`Review.stream/2` never closed stdin.** It called `Port.open({:spawn_executable, config.binary}, ...)` directly, so it was the one streaming path without the `/bin/sh ... < /dev/null` wrapper that #34 and #38 added everywhere else -- the wrapper that exists because the Codex CLI hangs on an inherited stdin.

**The close handshake blocked for 5s on every completed stream.** The `after` clause sent `{self(), :close}` and waited up to `5_000` for `:closed` even when `:exit_status` had already arrived, at which point the port is gone and the reply can never come. `Runner.Port` now tracks whether the process exited on its own and runs the handshake only on an early halt. There is a regression test asserting a completed stream returns in under two seconds.

**`config.timeout` reaches the streaming paths.** They previously ignored it in favor of a hardcoded `300_000`. The two runners enforce it as they can, which the moduledocs and README state plainly:

| Runner | meaning of `timeout` for a stream |
|---|---|
| `Runner.Port` | idle bound between lines (`300_000` when `nil`), which is what the hardcoded value was |
| `Runner.Forcola` | forcola's whole-run bound, falling back to `:forcola_default_timeout_ms` |

## The one contract decision

`Forcola.Stream.lines/2` raises `Forcola.Stream.Error` on a non-zero exit, a signal, a timeout, or a spawn failure. `Runner.Port` has always ended the stream silently in all four cases. Rather than have the same public `Exec.stream/2` raise or not depending on a config setting, `Runner.Forcola.stream_lines/4` translates the raise into a clean halt, and `CodexWrapper.Runner`'s contract states that a non-zero exit ends the stream without raising on either runner, pointing exit-code-sensitive callers at `execute/2`. forcola has already killed the process group by the time it raises, so nothing leaks.

The translation suspends forcola's reduction and rescues around each pull, which also means halting early still runs forcola's own kill-and-confirm cleanup.

## Tests

Nineteen new tests, +27 overall (301 -> 328).

- `runner_test.exs`, `Runner.Port.stream_lines/4`: one element per line without trailing newlines; stderr not merged; a non-zero exit halts rather than raises; `:cd` handed over as a string (`cmd_opts/1`'s shape, converted to a charlist for `Port.open/2`); `:env` passthrough; an early `Enum.take/2` terminating a `yes` that never exits; the timeout as an idle rather than whole-run bound (three lines 150ms apart under a 400ms bound all arrive); an idle producer cut off; a completed stream returning promptly.
- `runner_test.exs`, dispatch: routes to the configured runner; falls back to `Runner.Port` for a runner with no `stream_lines/4`.
- `runner/forcola_test.exs` (tagged `:forcola`, excluded when the shim is unresolvable): the same line/stderr assertions, plus each of the four raising cases translated to a halt, and a `:forcola_kill` test asserting an early `Enum.take/1` leaves no live pid.
- `stream_routing_test.exs` (new): a scripted runner stands in for the CLI, so what each builder hands the runner is observable without the real binary. Covers all four call sites, `--json` being forced, the configured binary being used, `stderr_to_stdout: false`, the config timeout arriving, non-JSON lines dropped, laziness (a halted consumer does not drain the runner), and `Session.stream/3` picking `exec` vs `exec resume` by `session_id`.

## Gates

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` (328 passed, forcola tests included -- the shim resolved locally)
- [x] `mix dialyzer` (0 errors)
- [x] `mix docs` (no warnings)
- [x] `mix credo --strict` on all 11 changed files -- clean, 69 checks, 205 mods/funs

Unlike the recent PRs in this series, credo ran clean over every changed file here, including the ones with `~s` sigils; the Elixir 1.20.2 tokenizer crash did not trip on this set. CI's pinned 1.19 runs it over the whole tree regardless.

## Base

Branched from `origin/main` (`b9709f2`). Touches `exec.ex`, `exec_resume.ex`, `review.ex`, and `README.md`, which open PRs #73 and #74 also touch -- #73 in `exec.ex`'s builder section and #74 in `review.ex`'s, both away from the `stream/2` functions this rewrites, so a rebase should be mechanical.