### PR TITLE
docs: record the tested Codex CLI version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ end
 Requires the `codex` CLI to be installed and on your PATH (or set `CODEX_CLI`
 to point at it).
 
+## Codex CLI compatibility
+
+Tested against codex-cli 0.145.0.
+
+The Codex CLI moves quickly and has removed flags between releases, so a
+wrapper release is only known to match the version recorded here. Subcommands
+this wrapper does not cover -- including the experimental `app-server`,
+`remote-control`, `cloud`, and `exec-server` -- are reachable through
+[`CodexWrapper.raw/1`](#raw-cli-escape-hatch):
+
+```elixir
+CodexWrapper.raw(["some", "new", "subcommand"])
+```
+
+Keeping the version current is part of the release checklist: bump the line
+above whenever the wrapper is verified against a newer CLI. The weekly
+`CLI contract` workflow installs the latest `@openai/codex` and runs
+`mix codex.contract`, opening a `cli-drift` issue when the wrapper emits a
+flag the CLI no longer accepts.
+
 ## Quick start
 
 ```elixir


### PR DESCRIPTION
Closes #66. Last item of the #52 Codex CLI 0.145.0 compatibility batch.

## Problem

The README does not say which Codex CLI versions the wrapper is known to work against. The only version markers in the repo are a code comment in `lib/codex_wrapper/session.ex` (Codex 0.119+ for thread_id extraction) and a line inside the Exec builder section about `--color`/`--oss`/`--local-provider`. Neither is where a reader looks first, and the CLI removed three flags between 0.119 and 0.145.

## Change

One new section in `README.md`, placed directly after the "Requires the `codex` CLI" note in Installation:

- `Tested against codex-cli 0.145.0.`
- The `CodexWrapper.raw/1` escape hatch, with the deliberately unwrapped experimental subcommands (`app-server`, `remote-control`, `cloud`, `exec-server`) named, and a link down to the existing "Raw CLI escape hatch" section.
- A release-process note: bump the version line when the wrapper is verified against a newer CLI, and the weekly `CLI contract` workflow (added in #72 for #64) installs the latest `@openai/codex`, runs `mix codex.contract`, and opens a `cli-drift` issue on drift.

The version recorded is the one the wrapper was verified against during the #52 batch, confirmed locally: `codex --version` => `codex-cli 0.145.0`.

No code changes.

## Checks

`mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix test` (301 passed), and `mix docs` all pass locally. Credo and dialyzer are unaffected by a README-only diff; CI runs both.
