### PR TITLE
test: add live Codex CLI contract coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,32 @@ The streaming paths (`Exec.stream/2` and friends) still use the built-in
 | `CodexWrapper.Commands.Completion` | Shell completion script generation |
 | `CodexWrapper.Commands.Version` | CLI version |
 
+## Testing
+
+The default suite does not invoke an authenticated Codex session:
+
+```bash
+mix test
+```
+
+Opt-in integration tests exercise the installed Codex CLI, including its
+live JSON event shape, session/thread identifier, feature-list format,
+and streaming Port path. They require `codex` on `PATH` and an active
+login:
+
+```bash
+mix test --include integration
+# or only the live checks
+mix test --only integration
+```
+
+The separate CLI contract check is authentication-free and verifies that
+the flags and config keys emitted by the wrapper are still accepted:
+
+```bash
+mix codex.contract
+```
+
 ## License
 
 MIT -- see [LICENSE](LICENSE).

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -1,0 +1,127 @@
+defmodule CodexWrapper.IntegrationTest do
+  @moduledoc """
+  Integration tests that run against the installed, authenticated Codex CLI.
+
+  Run with:
+
+      mix test --include integration
+      mix test --only integration
+  """
+
+  use ExUnit.Case, async: false
+
+  alias CodexWrapper.Commands.Features
+  alias CodexWrapper.{Config, Exec, JsonLineEvent, Session}
+
+  @moduletag :integration
+
+  setup do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "codex_wrapper_integration_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf(tmp_dir) end)
+
+    {:ok, config: Config.new(working_dir: tmp_dir, timeout: 120_000)}
+  end
+
+  describe "live JSON contract" do
+    test "emits the documented event sequence and a usable thread id", %{config: config} do
+      assert {:ok, events} =
+               "Reply with exactly: CODEX_WRAPPER_JSON_OK"
+               |> live_exec()
+               |> Exec.execute_json(config)
+
+      assert_event_contract(events)
+
+      thread_id = thread_id(events)
+      assert is_binary(thread_id)
+      assert thread_id != ""
+      assert Session.extract_session_id(events) == thread_id
+
+      assert Enum.any?(events, fn event ->
+               JsonLineEvent.type?(event, "item.completed") and
+                 get_in(JsonLineEvent.data(event), ["item", "type"]) == "agent_message"
+             end)
+    end
+  end
+
+  describe "live Port streaming" do
+    test "streams the same NDJSON event contract", %{config: config} do
+      events =
+        "Reply with exactly: CODEX_WRAPPER_STREAM_OK"
+        |> live_exec()
+        |> Exec.stream(config)
+        |> Enum.to_list()
+
+      assert_event_contract(events)
+      assert is_binary(thread_id(events))
+    end
+  end
+
+  describe "live feature list" do
+    test "retains the CLI's name, stage, and boolean-state rows", %{config: config} do
+      assert {:ok, output} = Features.list(config)
+
+      rows =
+        output
+        |> String.split("\n", trim: true)
+        |> Enum.filter(&Regex.match?(feature_row_pattern(), &1))
+
+      assert rows != []
+    end
+  end
+
+  defp live_exec(prompt) do
+    prompt
+    |> Exec.new()
+    |> Exec.sandbox(:read_only)
+    |> Exec.skip_git_repo_check()
+    |> Exec.ephemeral()
+    |> Exec.ignore_user_config()
+  end
+
+  defp assert_event_contract(events) do
+    event_types = Enum.map(events, &JsonLineEvent.event_type/1)
+
+    assert event_types != []
+
+    assert_in_order(event_types, [
+      "thread.started",
+      "turn.started",
+      "item.completed",
+      "turn.completed"
+    ])
+
+    assert Enum.all?(events, fn event ->
+             is_map(JsonLineEvent.data(event)) and is_binary(event.raw)
+           end)
+  end
+
+  defp assert_in_order(actual, expected) do
+    Enum.reduce(expected, actual, fn expected_type, remaining ->
+      case Enum.split_while(remaining, &(&1 != expected_type)) do
+        {_before, [^expected_type | rest]} ->
+          rest
+
+        {_before, []} ->
+          flunk("missing #{inspect(expected_type)} after #{inspect(actual)}")
+      end
+    end)
+
+    :ok
+  end
+
+  defp thread_id(events) do
+    events
+    |> Enum.find(&JsonLineEvent.type?(&1, "thread.started"))
+    |> JsonLineEvent.get("thread_id")
+  end
+
+  defp feature_row_pattern do
+    ~r/^\S+\s+(?:stable|experimental|under development|deprecated|removed)\s+(?:true|false)$/
+  end
+end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -111,8 +111,6 @@ defmodule CodexWrapper.IntegrationTest do
           flunk("missing #{inspect(expected_type)} after #{inspect(actual)}")
       end
     end)
-
-    :ok
   end
 
   defp thread_id(events) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,7 +6,8 @@ forcola_ready? =
   Code.ensure_loaded?(Forcola) and
     match?({:ok, _}, Forcola.Shim.path())
 
-exclude = if forcola_ready?, do: [], else: [:forcola]
+# Live tests make authenticated Codex requests and are always opt-in.
+exclude = [:integration] ++ if forcola_ready?, do: [], else: [:forcola]
 
 unless forcola_ready? do
   IO.puts("[test_helper] forcola shim not resolvable; excluding :forcola tests")


### PR DESCRIPTION
## Summary

- add opt-in integration tests against an installed, authenticated Codex CLI
- verify the live JSON event sequence, `thread_id` extraction, feature-list row shape, and Port streaming path
- exclude authenticated tests from the default suite and document the test/contract commands

## Why

Issue #52 still had three live assumptions that had only been surveyed manually. This turns those assumptions into repeatable checks without making ordinary CI require Codex authentication.

## Impact

The default test suite remains unchanged apart from reporting three excluded integration tests. Maintainers can run the live contract with `mix test --only integration` when updating the supported CLI version.

## Validation

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test` — 301 passed, 3 excluded
- `mix test --only integration` against `codex-cli 0.145.0` — 3 passed
- `mix codex.contract` — no drift
- `mix dialyzer`
- `mix docs`

`mix credo --strict` was attempted locally but Credo 1.7.17 crashes while tokenizing existing sigils under Elixir 1.20.2. Repository CI uses Elixir 1.19, where the existing checks run normally.

Tracks #52.
